### PR TITLE
moving from CurrentInterface to FunctionTask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   - bash tools/get_test_data.sh
 
 script:
-  - py.test -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
+  - py.test -vsx --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
 
 after_script:
 - codecov --file cov.xml --flags unittests -e TRAVIS_JOB_NUMBER

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_script:
   - bash tools/get_test_data.sh
 
 script:
-  - py.test -vsx --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
+  - py.test -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
 
 after_script:
 - codecov --file cov.xml --flags unittests -e TRAVIS_JOB_NUMBER

--- a/pydra/engine/auxiliary.py
+++ b/pydra/engine/auxiliary.py
@@ -1,7 +1,6 @@
 import pdb
 import inspect, os
 import logging
-from nipype import Node as Nipype1Node
 logger = logging.getLogger('nipype.workflow')
 
 # dj: might create a new class or move to State
@@ -418,19 +417,3 @@ class DotDict(dict):
     def __setstate__(self, state):
         self.update(state)
         self.__dict__ = self
-
-
-class CurrentInterface(object):
-    def __init__(self, interface, name):
-        self.nn = Nipype1Node(interface=interface, name=name)
-        self.output = {}
-
-    def run(self, inputs, base_dir, dir_nm_el):
-        self.nn.base_dir = os.path.join(base_dir, dir_nm_el)
-        for key, val in inputs.items():
-            key = key.split(".")[-1]
-            setattr(self.nn.inputs, key, val)
-        #have to set again self._output_dir in case of splitter
-        self.nn._output_dir = os.path.join(self.nn.base_dir, self.nn.name)
-        res = self.nn.run()
-        return res

--- a/pydra/engine/node.py
+++ b/pydra/engine/node.py
@@ -7,11 +7,12 @@ import numpy as np
 from collections import OrderedDict
 from copy import deepcopy, copy
 
-from nipype.utils.filemanip import loadpkl
-from nipype import logging, Function
+from nipype import logging
 
 from . import state
 from . import auxiliary as aux
+from .task import FunctionTask
+
 logger = logging.getLogger('nipype.workflow')
 
 
@@ -189,14 +190,6 @@ class NodeBase(object):
                 dir_nm_el_from, _ = from_node._directory_name_state_surv(state_dict)
                 inputs_dict["{}.{}".format(self.name, to_socket)] =\
                     getattr(from_node.results_dict[dir_nm_el_from].output, from_socket)
-                # should I read from files or just save results in node.results_dict
-                # if is_node(from_node):
-                #     out_from = self._reading_ci_output(
-                #         node=from_node, dir_nm_el=dir_nm_el_from, out_nm=from_socket)
-                #     if out_from:
-                #         inputs_dict["{}.{}".format(self.name, to_socket)] = out_from
-                #     else:
-                #         raise Exception("output from {} doesnt exist".format(from_node))
         return state_dict, inputs_dict
 
 
@@ -208,8 +201,7 @@ class NodeBase(object):
             dir_nm_el_from = "_".join([
                 "{}:{}".format(i, j) for i, j in list(state.items())])
             if is_node(from_node):
-                out_from = self._reading_ci_output(
-                    node=from_node, dir_nm_el=dir_nm_el_from, out_nm=from_socket)
+                out_from = getattr(from_node.results_dict[dir_nm_el_from].output, from_socket)
                 if out_from:
                     inputs_all.append(out_from)
                 else:
@@ -282,17 +274,17 @@ class NodeBase(object):
         # in py3.7 we can skip OrderedDict
         return OrderedDict(sorted(state_dict_el.items(), key=lambda t: t[0]))
 
-
-    def _reading_ci_output(self, dir_nm_el, out_nm, node=None):
-        """used for current interfaces: checking if the output exists and returns the path if it does"""
-        if not node:
-            node = self
-        result_pklfile = os.path.join(self.tasks_dict[dir_nm_el].output_dir, "_result.pklz")
-        if os.path.exists(result_pklfile) and os.stat(result_pklfile).st_size > 0:
-            out = getattr(self.tasks_dict[dir_nm_el].result().output, out_nm)
-            if out:
-                return out
-        return False
+    # TODO!: this might be not needed anymore when using FunctionTask
+    # def _reading_ci_output(self, dir_nm_el, out_nm, node=None):
+    #     """used for current interfaces: checking if the output exists and returns the path if it does"""
+    #     if not node:
+    #         node = self
+    #     result_pklfile = os.path.join(self.tasks_dict[dir_nm_el].output_dir, "_result.pklz")
+    #     if os.path.exists(result_pklfile) and os.stat(result_pklfile).st_size > 0:
+    #         out = getattr(self.tasks_dict[dir_nm_el].result().output, out_nm)
+    #         if out:
+    #             return out
+    #     return False
 
 
     def _directory_name_state_surv(self, state_dict):
@@ -459,7 +451,7 @@ class Node(NodeBase):
                         for inp in self.state._inner_splitter:
                             state_dict_copy_inner[inp] = inputs_dict[inp][ind_inner]
                         dir_nm_el, state_surv_dict = self._directory_name_state_surv(state_dict_copy_inner)
-                        output_el = self._reading_ci_output(dir_nm_el, out_nm=key_out)
+                        output_el = getattr(self.results_dict[dir_nm_el].output, key_out)
                         if not self.combiner:
                             self._output[key_out][dir_nm_el] = output_el
                         else:
@@ -467,14 +459,14 @@ class Node(NodeBase):
                 else:
                     dir_nm_el, state_surv_dict = self._directory_name_state_surv(state_dict)
                     if self.splitter:
-                        output_el = self._reading_ci_output(dir_nm_el, out_nm=key_out)
+                        output_el =  getattr(self.results_dict[dir_nm_el].output, key_out)
                         if not self.combiner: # only splitter
                             self._output[key_out][dir_nm_el] = output_el
                         else:
                             self._combined_output(key_out, state_dict, output_el)
                     else:
                         self._output[key_out] = \
-                            (state_surv_dict, self._reading_ci_output(dir_nm_el, out_nm=key_out))
+                            (state_surv_dict, getattr(self.results_dict[dir_nm_el].output, key_out))
         return self._output
 
 
@@ -494,12 +486,12 @@ class Node(NodeBase):
                         state_dict_copy_inner[inp] = inputs_dict[inp][ind_inner]
                     dir_nm_el, _ = self._directory_name_state_surv(state_dict_copy_inner)
                     for key_out in self.output_names:
-                        if not self._reading_ci_output(dir_nm_el, key_out):
+                        if not getattr(self.results_dict[dir_nm_el].output, key_out):
                             return False
             else:
                 dir_nm_el, _ = self._directory_name_state_surv(state_dict)
                 for key_out in self.output_names:
-                    if not self._reading_ci_output(dir_nm_el, key_out):
+                    if not getattr(self.results_dict[dir_nm_el].output, key_out):
                         return False
         self._is_complete = True
         return True
@@ -672,41 +664,18 @@ class Workflow(NodeBase):
 
 
     # TODO: workingir shouldn't have None
-    def add(self, runnable, name=None, workingdir=None, inputs=None, input_names=None,
+    def add(self, runnable, name=None, workingdir=None, inputs=None,
             output_names=None, splitter=None, combiner=None, write_state=True, **kwargs):
-        if is_function(runnable):
+        # TODO: should I also accept normal function?
+        if is_function_task(runnable):
             if not output_names:
                 output_names = ["out"]
-            if input_names is None:
-                raise Exception("you need to specify input_names")
-            if not name:
-                raise Exception("you have to specify name for the node")
-            nipype1_interf = Function(function=runnable, input_names=input_names,
-                                      output_names=output_names)
-            interface = aux.CurrentInterface(interface=nipype1_interf, name="addtwo")
-            if not workingdir:
-                workingdir = name
-            node = Node(interface=interface, workingdir=workingdir, name=name,
-                        inputs=inputs, splitter=splitter, other_splitters=self._node_splitters,
-                        combiner=combiner, output_names=output_names,
-                        write_state=write_state)
-        elif is_current_interface(runnable):
             if not name:
                 raise Exception("you have to specify name for the node")
             if not workingdir:
                 workingdir = name
             node = Node(interface=runnable, workingdir=workingdir, name=name,
                         inputs=inputs, splitter=splitter, other_splitters=self._node_splitters,
-                        combiner=combiner, output_names=output_names,
-                        write_state=write_state)
-        elif is_nipype_interface(runnable):
-            ci = aux.CurrentInterface(interface=runnable, name=name)
-            if not name:
-                raise Exception("you have to specify name for the node")
-            if not workingdir:
-                workingdir = name
-            node = Node(interface=ci, workingdir=workingdir, name=name, inputs=inputs,
-                        splitter=splitter, other_splitters=self._node_splitters,
                         combiner=combiner, output_names=output_names,
                         write_state=write_state)
         elif is_node(runnable):
@@ -809,14 +778,8 @@ class Workflow(NodeBase):
 def is_function(obj):
     return hasattr(obj, '__call__')
 
-
-def is_current_interface(obj):
-    return type(obj) is aux.CurrentInterface
-
-
-def is_nipype_interface(obj):
-    return hasattr(obj, "_run_interface")
-
+def is_function_task(obj):
+    return type(obj) is FunctionTask
 
 def is_node(obj):
     return type(obj) is Node

--- a/pydra/engine/node.py
+++ b/pydra/engine/node.py
@@ -188,7 +188,7 @@ class NodeBase(object):
             else:
                 dir_nm_el_from, _ = from_node._directory_name_state_surv(state_dict)
                 inputs_dict["{}.{}".format(self.name, to_socket)] =\
-                    from_node.results_dict[dir_nm_el_from]["output"][from_socket]
+                    getattr(from_node.results_dict[dir_nm_el_from].output, from_socket)
                 # should I read from files or just save results in node.results_dict
                 # if is_node(from_node):
                 #     out_from = self._reading_ci_output(
@@ -431,6 +431,7 @@ class Node(NodeBase):
         print("Run interface el, dict={}".format(state_surv_dict))
         logger.debug("Run interface el, name={}, inputs_dict={}, state_dict={}".format(
             self.name, inputs_dict, state_surv_dict))
+        os.makedirs(os.path.join(os.getcwd(), self.workingdir), exist_ok=True)
         self.interface.cache_dir = os.path.join(os.getcwd(), self.workingdir)
         interf_inputs = dict((k.split(".")[1], v) for k,v in inputs_dict.items())
         res = self.interface.run(**interf_inputs)

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -256,14 +256,20 @@ class BaseTask:
     def cache_dir(self, location):
         self._cache_dir = Path(location)
 
+    @property
+    def output_dir(self):
+        return self._cache_dir / self.checksum
+
     def audit_check(self, flag):
         return self.audit_flags & flag
 
     def __call__(self, cache_locations=None, **kwargs):
         return self.run(cache_locations=cache_locations, **kwargs)
 
-    def run(self, cache_locations=None, **kwargs):
+    def run(self, cache_locations=None, environment=None, cache_dir=None, **kwargs):
         self.inputs = dc.replace(self.inputs, **kwargs)
+        if cache_dir:
+            self.cache_dir = cache_dir
         checksum = self.checksum
 
         # Eagerly retrieve cached
@@ -281,7 +287,7 @@ class BaseTask:
         if self._cache_dir is None:
             self.cache_dir = mkdtemp()
         cwd = os.getcwd()
-        odir = self.cache_dir / checksum
+        odir = self.output_dir
         if not self.can_resume and odir.exists():
             shutil.rmtree(odir)
         odir.mkdir(parents=True, exist_ok=True if self.can_resume else False)

--- a/pydra/engine/tests/test_node.py
+++ b/pydra/engine/tests/test_node.py
@@ -394,7 +394,7 @@ def test_workflow_2b(plugin):
 def test_workflow_3(plugin, change_dir):
     """using add(node) method"""
     wf = Workflow(name="wf3", workingdir="test_wf3_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     na.split(splitter="a", inputs={"a": [3, 5]})
     # using add method (as in the Satra's example) with a node
     wf.add(na)
@@ -417,7 +417,7 @@ def test_workflow_3a(plugin, change_dir):
     """using add(interface) method"""
     wf = Workflow(name="wf3a", workingdir="test_wf3a_{}".format(plugin))
     # using the add method with an interface
-    wf.add(interf_addtwo, workingdir="na", splitter="a", inputs={"a": [3, 5]}, name="NA",
+    wf.add(fun_addtwo(), workingdir="na", splitter="a", inputs={"a": [3, 5]}, name="NA",
            output_names=["out"])
 
     assert wf.nodes[0].splitter == "NA.a"
@@ -438,7 +438,7 @@ def test_workflow_3b(plugin, change_dir):
     """using add (function) method"""
     wf = Workflow(name="wf3b", workingdir="test_wf3b_{}".format(plugin))
     # using the add method with a function
-    wf.add(fun_addtwo, input_names=["a"], workingdir="na", splitter="a",
+    wf.add(fun_addtwo(), input_names=["a"], workingdir="na", splitter="a",
            inputs={"a": [3, 5]}, name="NA", output_names=["out"])
 
     assert wf.nodes[0].splitter == "NA.a"
@@ -460,10 +460,10 @@ def test_workflow_4(plugin, change_dir):
         using wf.connect to connect two nodes
     """
     wf = Workflow(name="wf4", workingdir="test_wf4_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     na.split(splitter="a", inputs={"a": [3, 5]})
     wf.add(na)
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # explicit splitter with a variable from the previous node
     # providing inputs with b
     nb.split(splitter=("NA.a", "c"), inputs={"c": [2, 1]})
@@ -491,12 +491,12 @@ def test_workflow_4(plugin, change_dir):
 def test_workflow_4a(plugin, change_dir):
     """ using add(node) method with kwarg arg to connect nodes (instead of wf.connect) """
     wf = Workflow(name="wf4a", workingdir="test_wf4a_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     na.split(splitter="a", inputs={"a": [3, 5]})
     wf.add(na)
 
 
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # explicit splitter with a variable from the previous node
     nb.split(splitter=("NA.a", "c"), inputs={"c": [2, 1]})
     # instead of "connect", using kwrg argument in the add method as in the example
@@ -524,9 +524,9 @@ def test_workflow_4b(plugin, change_dir):
         using wf.connect to connect two nodes
     """
     wf = Workflow(name="wf4b", workingdir="test_wf4b_{}".format(plugin))
-    wf.add(runnable=interf_addtwo, name="NA", workingdir="na", output_names=["out"],
+    wf.add(runnable=fun_addtwo(), name="NA", workingdir="na", output_names=["out"],
            splitter="a", inputs={"a": [3, 5]})
-    wf.add(runnable=interf_addvar, name="NB", workingdir="nb", output_names=["out"],
+    wf.add(runnable=fun_addvar(), name="NB", workingdir="nb", output_names=["out"],
            splitter=("NA.a", "c"), inputs={"c": [2, 1]})
     # connect method as it is in the current version
     wf.connect("NA", "out", "NB", "b")
@@ -554,9 +554,9 @@ def test_workflow_4c(plugin, change_dir):
         using wf.connect to connect two nodes
     """
     wf = Workflow(name="wf4c", workingdir="test_wf4c_{}".format(plugin))
-    wf.add(runnable=interf_addtwo, name="NA", workingdir="na", output_names=["out"],
+    wf.add(runnable=fun_addtwo(), name="NA", workingdir="na", output_names=["out"],
            inputs={"a": [3, 5]})
-    wf.add(runnable=interf_addvar, name="NB", workingdir="nb", output_names=["out"],
+    wf.add(runnable=fun_addvar(), name="NB", workingdir="nb", output_names=["out"],
            inputs={"c": [2, 1]})
     wf.split_node(splitter="a", node="NA")
     wf.split_node(splitter=("NA.a", "c"), node="NB")
@@ -585,9 +585,9 @@ def test_workflow_4d(plugin, change_dir):
         using wf.connect to connect two nodes
     """
     wf = Workflow(name="wf4d", workingdir="test_wf4d_{}".format(plugin))
-    wf.add(runnable=interf_addtwo, name="NA", workingdir="na", output_names=["out"],
+    wf.add(runnable=fun_addtwo(), name="NA", workingdir="na", output_names=["out"],
            inputs={"a": [3, 5]})
-    wf.add(runnable=interf_addvar, name="NB", workingdir="nb", output_names=["out"],
+    wf.add(runnable=fun_addvar(), name="NB", workingdir="nb", output_names=["out"],
            inputs={"c": [2, 1]})
 
     wf.connect("NA", "out", "NB", "b")
@@ -618,7 +618,7 @@ def test_workflow_4d(plugin, change_dir):
 def test_workflow_5(plugin, change_dir):
     """using a split method for one node"""
     wf = Workflow(name="wf5", workingdir="test_wf5_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
     wf.add(na)
     # using the split method after add (using splitter for the last added node as default)
@@ -639,7 +639,7 @@ def test_workflow_5(plugin, change_dir):
 def test_workflow_5a(plugin, change_dir):
     """using a split method for one node (using add and split in one chain)"""
     wf = Workflow(name="wf5a", workingdir="test_wf5a_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
     wf.add(na).split_node(splitter="a", inputs={"a": [3, 5]})
 
@@ -658,9 +658,9 @@ def test_workflow_5a(plugin, change_dir):
 def test_workflow_6(plugin, change_dir):
     """using a split method for two nodes (using last added node as default)"""
     wf = Workflow(name="wf6", workingdir="test_wf6_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # using the split methods after add (using splitter for the last added nodes as default)
     wf.add(na)
     wf.split_node(splitter="a", inputs={"a": [3, 5]})
@@ -688,9 +688,9 @@ def test_workflow_6(plugin, change_dir):
 def test_workflow_6a(plugin, change_dir):
     """using a split method for two nodes (specifying the node)"""
     wf = Workflow(name="wf6a", workingdir="test_wf6a_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # using the split method after add (specifying the node)
     wf.add(na)
     wf.add(nb)
@@ -719,8 +719,8 @@ def test_workflow_6a(plugin, change_dir):
 def test_workflow_6b(plugin, change_dir):
     """using a split method for two nodes (specifying the node), using kwarg arg instead of connect"""
     wf = Workflow(name="wf6b", workingdir="test_wf6b_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
 
     wf.add(na)
     wf.add(nb, b="NA.out")
@@ -751,7 +751,7 @@ def test_workflow_7(plugin, change_dir):
     """using inputs for workflow and connect_workflow"""
     # adding inputs to the workflow directly
     wf = Workflow(name="wf7", inputs={"wfa": [3, 5]}, workingdir="test_wf7_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
     wf.add(na)
     # connecting the node with inputs from the workflow
@@ -773,7 +773,7 @@ def test_workflow_7(plugin, change_dir):
 def test_workflow_7a(plugin, change_dir):
     """using inputs for workflow and kwarg arg in add (instead of connect)"""
     wf = Workflow(name="wf7a", inputs={"wfa": [3, 5]}, workingdir="test_wf7a_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     # using kwrg argument in the add method (instead of connect or connect_wf_input
     wf.add(na, a="wfa")
     wf.split_node(splitter="a")
@@ -793,9 +793,9 @@ def test_workflow_7a(plugin, change_dir):
 def test_workflow_8(plugin, change_dir):
     """using inputs for workflow and connect_wf_input for the second node"""
     wf = Workflow(name="wf8", workingdir="test_wf8_{}".format(plugin), inputs={"c": 10})
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     na.split(splitter="a", inputs={"a": [3, 5]})
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
 
     wf.add_nodes([na, nb])
     wf.connect("NA", "out", "NB", "b")
@@ -825,10 +825,10 @@ def test_workflow_8(plugin, change_dir):
 def test_workflow_9(plugin, change_dir):
     """using add(interface) method and splitter from previous nodes"""
     wf = Workflow(name="wf9", workingdir="test_wf9_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addtwo, workingdir="na",
+    wf.add(name="NA", runnable=fun_addtwo(), workingdir="na",
            output_names=["out"]).split_node(splitter="a", inputs={"a": [3, 5]})
     # _NA means that I'm using splitter from the NA node, it's the same as ("NA.a", "b")
-    wf.add(name="NB", runnable=interf_addvar, workingdir="nb", b="NA.out",
+    wf.add(name="NB", runnable=fun_addvar(), workingdir="nb", b="NA.out",
            output_names=["out"]).split_node(splitter=("_NA", "c"), inputs={"c": [2, 1]})
 
     sub = Submitter(runnable=wf, plugin=plugin)
@@ -851,11 +851,11 @@ def test_workflow_9(plugin, change_dir):
 def test_workflow_10(plugin, change_dir):
     """using add(interface) method and scalar splitter from previous nodes"""
     wf = Workflow(name="wf10", workingdir="test_wf10_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addvar, workingdir="na",
+    wf.add(name="NA", runnable=fun_addvar(), workingdir="na",
            output_names=["out"]).split_node(
         splitter=("b", "c"), inputs={"b": [3, 5], "c": [0, 10]})
     # _NA means that I'm using splitter from the NA node, it's the same as (("NA.a", NA.b), "b")
-    wf.add(name="NB", runnable=interf_addvar, workingdir="nb", b="NA.out",
+    wf.add(name="NB", runnable=fun_addvar(), workingdir="nb", b="NA.out",
            output_names=["out"]).split_node(splitter=("_NA", "c"), inputs={"c": [2, 1]})
 
     sub = Submitter(runnable=wf, plugin=plugin)
@@ -878,11 +878,11 @@ def test_workflow_10(plugin, change_dir):
 def test_workflow_10a(plugin, change_dir):
     """using add(interface) method and vector splitter from previous nodes"""
     wf = Workflow(name="wf10a", workingdir="test_wf10a_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addvar, workingdir="na",
+    wf.add(name="NA", runnable=fun_addvar(), workingdir="na",
            output_names=["out"]).split_node(
             splitter=["b", "c"], inputs={"b": [3, 5], "c": [0, 10]})
     # _NA means that I'm using splitter from the NA node, it's the same as (["NA.a", NA.b], "b")
-    wf.add(name="NB", runnable=interf_addvar, workingdir="nb", b="NA.out",
+    wf.add(name="NB", runnable=fun_addvar(), workingdir="nb", b="NA.out",
            output_names=["out"]).split_node(
             splitter=("_NA", "c"), inputs={"c": [[2, 1], [0, 0]]})
 
@@ -911,13 +911,13 @@ def test_workflow_10a(plugin, change_dir):
 def test_workflow_11(plugin, change_dir):
     """using add(interface) method and vector splitter from previous two nodes"""
     wf = Workflow(name="wf11", workingdir="test_wf11_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addvar, workingdir="na",
+    wf.add(name="NA", runnable=fun_addvar(), workingdir="na",
            output_names=["out"]).split_node(
             splitter=("b", "c"), inputs={"b": [3, 5],"c": [0, 10]})
-    wf.add(name="NB", runnable=interf_addtwo, workingdir="nb",
+    wf.add(name="NB", runnable=fun_addtwo(), workingdir="nb",
            output_names=["out"]).split_node(splitter="a", inputs={"a": [2, 1]})
     # _NA, _NB means that I'm using splitters from the NA/NB nodes, it's the same as [("NA.a", NA.b), "NB.a"]
-    wf.add(name="NC", runnable=interf_addvar, workingdir="nc", b="NA.out", c="NB.out",
+    wf.add(name="NC", runnable=fun_addvar(), workingdir="nc", b="NA.out", c="NB.out",
            output_names=["out"]).split_node(splitter=["_NA", "_NB"])  # TODO: this should eb default?
 
     sub = Submitter(runnable=wf, plugin=plugin)
@@ -947,8 +947,8 @@ def test_workflow_12(plugin, change_dir):
     """testing if wf.result works (the same workflow as in test_workflow_6)"""
     wf = Workflow(name="wf12", workingdir="test_wf12_{}".format(plugin),
         wf_output_names=[("NA", "out", "NA_out"), ("NB", "out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # using the split methods after add (using splitter for the last added nodes as default)
     wf.add(na)
     wf.split_node(splitter="a", inputs={"a": [3, 5]})
@@ -983,8 +983,8 @@ def test_workflow_12a(plugin, change_dir):
     """testing if wf.result raises exceptione (the same workflow as in test_workflow_6)"""
     wf = Workflow(name="wf12a",workingdir="test_wf12a_{}".format(plugin),
         wf_output_names=[("NA", "out", "wf_out"), ("NB", "out", "wf_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # using the split methods after add (using splitter for the last added nodes as default)
     wf.add(na)
     wf.split_node(splitter="a", inputs={"a": [3, 5]})
@@ -1008,7 +1008,7 @@ def test_workflow_13(plugin, change_dir):
     wf = Workflow(name="wf13", inputs={"wfa": [3, 5]}, splitter="wfa",
         workingdir="test_wf13_{}".format(plugin),
         wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     wf.add(na)
     wf.connect_wf_input("wfa", "NA", "a")
 
@@ -1032,7 +1032,7 @@ def test_workflow_13a(plugin, change_dir):
     wf = Workflow(name="wf13a", inputs={"wfa": [3, 5]}, splitter="wfa",
         workingdir="test_wf13a_{}".format(plugin),
         wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addvar, workingdir="na", splitter="c",
+    na = Node(name="NA", interface=fun_addvar(), workingdir="na", splitter="c",
               inputs={"c": [10, 20]}, output_names=["out"])
     wf.add(na)
     wf.connect_wf_input("wfa", "NA", "b")
@@ -1060,7 +1060,7 @@ def test_workflow_13b(plugin, change_dir):
     wf = Workflow(name="wf13b", inputs={"wfa": [3, 5]},
         workingdir="test_wf13b_{}".format(plugin),
         wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na",
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na",
               output_names=["out"])
     wf.add(na).split(splitter="wfa")
     wf.connect_wf_input("wfa", "NA", "a")
@@ -1082,7 +1082,7 @@ def test_workflow_13c(plugin, change_dir):
     """using inputs for workflow and connect_wf_input, using wf.split(splitter, inputs)"""
     wf = Workflow(name="wf13c", workingdir="test_wf13c_{}".format(plugin),
         wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na",
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na",
               output_names=["out"])
     wf.add(na).split(splitter="wfa", inputs={"wfa": [3, 5]})
     wf.connect_wf_input("wfa", "NA", "a")
@@ -1105,7 +1105,7 @@ def test_workflow_14(plugin, change_dir):
     wf = Workflow(name="wf14", inputs={"wfb": [3, 5], "wfc": [10, 20]},
                   splitter=("wfb", "wfc"), workingdir="test_wf14_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addvar, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar(), workingdir="na", output_names=["out"])
     wf.add(na)
     wf.connect_wf_input("wfb", "NA", "b")
     wf.connect_wf_input("wfc", "NA", "c")
@@ -1129,7 +1129,7 @@ def test_workflow_15(plugin, change_dir):
     wf = Workflow(name="wf15", inputs={"wfb": [3, 5], "wfc": [10, 20]},
                   splitter=["wfb", "wfc"], workingdir="test_wf15_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addvar, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar(), workingdir="na", output_names=["out"])
     wf.add(na)
     wf.connect_wf_input("wfb", "NA", "b")
     wf.connect_wf_input("wfc", "NA", "c")
@@ -1154,7 +1154,7 @@ def test_workflow_15(plugin, change_dir):
 @python35_only
 def test_workflow_16(plugin, change_dir):
     """workflow with a workflow as a node (no splitter)"""
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", inputs={"a": 3},
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", inputs={"a": 3},
               output_names=["out"])
     wfa = Workflow(name="wfa", workingdir="test_wfa", wf_output_names=[("NA", "out", "NA_out")])
     wfa.add(na)
@@ -1175,7 +1175,7 @@ def test_workflow_16(plugin, change_dir):
 @python35_only
 def test_workflow_16a(plugin, change_dir):
     """workflow with a workflow as a node (no splitter, using connect_wf_input in wfa)"""
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na",
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na",
               output_names=["out"])
     wfa = Workflow(name="wfa", workingdir="test_wfa", inputs={"a": 3},
             wf_output_names=[("NA", "out", "NA_out")])
@@ -1198,7 +1198,7 @@ def test_workflow_16a(plugin, change_dir):
 @python35_only
 def test_workflow_16b(plugin, change_dir):
     """workflow with a workflow as a node (no splitter, using connect_wf_input in wfa and wf)"""
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     wfa = Workflow(name="wfa", workingdir="test_wfa", wf_output_names=[("NA", "out", "NA_out")])
     wfa.add(na)
     wfa.connect_wf_input("a", "NA", "a")
@@ -1220,7 +1220,7 @@ def test_workflow_16b(plugin, change_dir):
 @python35_only
 def test_workflow_17(plugin, change_dir):
     """workflow with a workflow as a node with splitter (like 14 but with a splitter)"""
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na",
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na",
               inputs={"a": [3, 5]}, splitter="a", output_names=["out"])
     wfa = Workflow(name="wfa", workingdir="test_wfa", wf_output_names=[("NA", "out", "NA_out")])
     wfa.add(na)
@@ -1246,12 +1246,12 @@ def test_workflow_18(plugin, change_dir):
     """workflow with two nodes, and one is a workflow (no splitter)"""
     wf = Workflow(name="wf18", workingdir="test_wf18_{}".format(plugin),
             wf_output_names=[("wfb", "NB_out"), ("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", inputs={"a": 3},
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", inputs={"a": 3},
               output_names=["out"])
     wf.add(na)
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb",
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb",
               output_names=["out"])
     wfb = Workflow(name="wfb", workingdir="test_wfb", inputs={"c": 10},
             wf_output_names=[("NB", "out", "NB_out")])
@@ -1281,12 +1281,12 @@ def test_workflow_19(plugin, change_dir):
     """workflow with two nodes, and one is a workflow (with splitter)"""
     wf = Workflow(name="wf19", workingdir="test_wf19_{}".format(plugin),
         wf_output_names=[("wfb", "NB_out"), ("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na",
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na",
               output_names=["out"])
     na.split(splitter="a", inputs={"a": [3, 5]})
     wf.add(na)
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb",
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb",
               output_names=["out"])
     wfb = Workflow(name="wfb", workingdir="test_wfb", inputs={"c": 10},
         wf_output_names=[("NB", "out", "NB_out")])
@@ -1330,12 +1330,12 @@ def test_workflow_19a(plugin, change_dir):
     """
     wf = Workflow(name="wf19a", workingdir="test_wf19a_{}".format(plugin),
         wf_output_names=[("wfb", "NB_out"), ("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na",
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na",
               output_names=["out"], write_state=False)
     na.split(splitter="a", inputs={"a": [3, 5]})
     wf.add(na)
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb",
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb",
               output_names=["out"])
     wfb = Workflow(name="wfb", workingdir="test_wfb", inputs={"c": 10},
         wf_output_names=[("NB", "out", "NB_out")], write_state=False)

--- a/pydra/engine/tests/test_node.py
+++ b/pydra/engine/tests/test_node.py
@@ -388,7 +388,7 @@ def test_workflow_2b(plugin):
 
 
 # using add method to add nodes
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_3(plugin, change_dir):
@@ -410,7 +410,7 @@ def test_workflow_3(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_3a(plugin, change_dir):
@@ -431,7 +431,7 @@ def test_workflow_3a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_3b(plugin, change_dir):
@@ -452,7 +452,7 @@ def test_workflow_3b(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4(plugin, change_dir):
@@ -485,7 +485,7 @@ def test_workflow_4(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4a(plugin, change_dir):
@@ -516,7 +516,7 @@ def test_workflow_4a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4b(plugin, change_dir):
@@ -546,7 +546,7 @@ def test_workflow_4b(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4c(plugin, change_dir):
@@ -577,7 +577,7 @@ def test_workflow_4c(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4d(plugin, change_dir):
@@ -612,7 +612,7 @@ def test_workflow_4d(plugin, change_dir):
 
 # using split after add method
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_5(plugin, change_dir):
@@ -633,7 +633,7 @@ def test_workflow_5(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_5a(plugin, change_dir):
@@ -652,7 +652,7 @@ def test_workflow_5a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_6(plugin, change_dir):
@@ -682,7 +682,7 @@ def test_workflow_6(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_6a(plugin, change_dir):
@@ -713,7 +713,7 @@ def test_workflow_6a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_6b(plugin, change_dir):
@@ -744,7 +744,7 @@ def test_workflow_6b(plugin, change_dir):
 
 # tests for a workflow that have its own input
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_7(plugin, change_dir):
@@ -767,7 +767,7 @@ def test_workflow_7(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_7a(plugin, change_dir):
@@ -787,7 +787,7 @@ def test_workflow_7a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_8(plugin, change_dir):
@@ -819,7 +819,7 @@ def test_workflow_8(plugin, change_dir):
 
 # testing if _NA in splitter works, using interfaces in add
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_9(plugin, change_dir):
@@ -845,7 +845,7 @@ def test_workflow_9(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_10(plugin, change_dir):
@@ -872,7 +872,7 @@ def test_workflow_10(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_10a(plugin, change_dir):
@@ -906,6 +906,7 @@ def test_workflow_10a(plugin, change_dir):
 
 
 # TODO: this test started sometimes failing for mp and cf
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_11(plugin, change_dir):
@@ -940,7 +941,7 @@ def test_workflow_11(plugin, change_dir):
 
 # checking workflow.result
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_12(plugin, change_dir):
@@ -976,7 +977,7 @@ def test_workflow_12(plugin, change_dir):
         assert wf.result["out"][i][0] == res[0]
         assert wf.result["out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_12a(plugin, change_dir):
@@ -1000,7 +1001,7 @@ def test_workflow_12a(plugin, change_dir):
 
 
 # tests for a workflow that have its own input and splitter
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_13(plugin, change_dir):
@@ -1052,7 +1053,7 @@ def test_workflow_13a(plugin, change_dir):
             assert list(wf.result["NA_out"][i][1].values())[j][0] == res[1][j][0]
             assert list(wf.result["NA_out"][i][1].values())[j][1] == res[1][j][1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_13b(plugin, change_dir):
@@ -1075,7 +1076,7 @@ def test_workflow_13b(plugin, change_dir):
         assert wf.result["NA_out"][i][0] == res[0]
         assert wf.result["NA_out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_13c(plugin, change_dir):
@@ -1097,7 +1098,7 @@ def test_workflow_13c(plugin, change_dir):
         assert wf.result["NA_out"][i][0] == res[0]
         assert wf.result["NA_out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_14(plugin, change_dir):
@@ -1121,7 +1122,7 @@ def test_workflow_14(plugin, change_dir):
         assert wf.result["NA_out"][i][0] == res[0]
         assert wf.result["NA_out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_15(plugin, change_dir):
@@ -1149,7 +1150,7 @@ def test_workflow_15(plugin, change_dir):
 
 
 # workflow as a node
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_16(plugin, change_dir):
@@ -1170,7 +1171,7 @@ def test_workflow_16(plugin, change_dir):
     assert wf.is_complete
     assert wf.result["wfa_out"] == ({}, 5)
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_16a(plugin, change_dir):
@@ -1193,7 +1194,7 @@ def test_workflow_16a(plugin, change_dir):
     assert wf.is_complete
     assert wf.result["wfa_out"] == ({}, 5)
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_16b(plugin, change_dir):
@@ -1215,7 +1216,7 @@ def test_workflow_16b(plugin, change_dir):
     assert wf.is_complete
     assert wf.result["wfa_out"] == ({}, 5)
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_17(plugin, change_dir):
@@ -1239,7 +1240,7 @@ def test_workflow_17(plugin, change_dir):
         assert wf.result["wfa_out"][i][0] == res[0]
         assert wf.result["wfa_out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_18(plugin, change_dir):
@@ -1274,7 +1275,7 @@ def test_workflow_18(plugin, change_dir):
     # the naming should have names with workflows??
     assert wf.result["NB_out"] == ({}, 15)
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_19(plugin, change_dir):
@@ -1321,7 +1322,7 @@ def test_workflow_19(plugin, change_dir):
         assert wf.result["NB_out"][i][0] == res[0]
         assert wf.result["NB_out"][i][1] == res[1]
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_19a(plugin, change_dir):
@@ -1377,7 +1378,7 @@ T1_file_list = [
     "/Users/dorota/nipype_workshop/data/ds000114/sub-01/ses-test/anat/sub-01_ses-test_T1w.nii.gz",
     "/Users/dorota/nipype_workshop/data/ds000114/sub-02/ses-test/anat/sub-02_ses-test_T1w.nii.gz"
     ]
-
+@pytest.mark.skip("WIP")
 @pytest.mark.skipif(not DS114_DIR.exists(), reason="Missing $PYDRA_TEST_DATA/ds000114")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
@@ -1397,7 +1398,7 @@ def test_current_node_1(change_dir, plugin):
     # TODO (res): nodes only returns relative path
     assert "out_file" in nn.output.keys()
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.skipif(not DS114_DIR.exists(), reason="Missing $PYDRA_TEST_DATA/ds000114")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
@@ -1426,7 +1427,7 @@ def test_current_node_2(change_dir, plugin):
     assert "NA.in_file:0" in nn.output["out_file"].keys()
     assert "NA.in_file:1" in nn.output["out_file"].keys()
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.skipif(not DS114_DIR.exists(), reason="Missing $PYDRA_TEST_DATA/ds000114")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
@@ -1455,7 +1456,7 @@ def test_current_wf_1(change_dir, plugin):
 
     assert "fsl_out" in wf.output.keys()
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.skipif(not DS114_DIR.exists(), reason="Missing $PYDRA_TEST_DATA/ds000114")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
@@ -1484,7 +1485,7 @@ def test_current_wf_1a(change_dir, plugin):
 
     assert "fsl_out" in wf.output.keys()
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.skipif(not DS114_DIR.exists(), reason="Missing $PYDRA_TEST_DATA/ds000114")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
@@ -1511,7 +1512,7 @@ def test_current_wf_1b(change_dir, plugin):
 
     assert "fsl_out" in wf.output.keys()
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.skipif(not DS114_DIR.exists(), reason="Missing $PYDRA_TEST_DATA/ds000114")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
@@ -1537,7 +1538,7 @@ def test_current_wf_1c(change_dir, plugin):
 
     assert "fsl_out" in wf.output.keys()
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.skipif(not DS114_DIR.exists(), reason="Missing $PYDRA_TEST_DATA/ds000114")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
@@ -1575,7 +1576,7 @@ def test_current_wf_2(change_dir, plugin):
     assert 'cw2.in_file:0' in wf.output["fsl_out"].keys()
     assert 'cw2.in_file:1' in wf.output["fsl_out"].keys()
 
-
+@pytest.mark.skip("WIP")
 @pytest.mark.skipif(not DS114_DIR.exists(), reason="Missing $PYDRA_TEST_DATA/ds000114")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only

--- a/pydra/engine/tests/test_node.py
+++ b/pydra/engine/tests/test_node.py
@@ -9,7 +9,6 @@ from nipype.interfaces import fsl
 from nipype import Function
 
 from ..node import Node, Workflow
-from ..auxiliary import CurrentInterface
 from ..submitter import Submitter
 from ..task import to_task
 
@@ -388,7 +387,7 @@ def test_workflow_2b(plugin):
 
 
 # using add method to add nodes
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_3(plugin, change_dir):
@@ -410,7 +409,7 @@ def test_workflow_3(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_3a(plugin, change_dir):
@@ -431,14 +430,14 @@ def test_workflow_3a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_3b(plugin, change_dir):
     """using add (function) method"""
     wf = Workflow(name="wf3b", workingdir="test_wf3b_{}".format(plugin))
     # using the add method with a function
-    wf.add(fun_addtwo(), input_names=["a"], workingdir="na", splitter="a",
+    wf.add(fun_addtwo(), workingdir="na", splitter="a",
            inputs={"a": [3, 5]}, name="NA", output_names=["out"])
 
     assert wf.nodes[0].splitter == "NA.a"
@@ -452,7 +451,7 @@ def test_workflow_3b(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4(plugin, change_dir):
@@ -485,7 +484,7 @@ def test_workflow_4(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4a(plugin, change_dir):
@@ -516,7 +515,7 @@ def test_workflow_4a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4b(plugin, change_dir):
@@ -546,7 +545,7 @@ def test_workflow_4b(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4c(plugin, change_dir):
@@ -577,7 +576,7 @@ def test_workflow_4c(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_4d(plugin, change_dir):
@@ -612,7 +611,7 @@ def test_workflow_4d(plugin, change_dir):
 
 # using split after add method
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_5(plugin, change_dir):
@@ -633,7 +632,7 @@ def test_workflow_5(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_5a(plugin, change_dir):
@@ -652,7 +651,7 @@ def test_workflow_5a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_6(plugin, change_dir):
@@ -682,7 +681,7 @@ def test_workflow_6(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_6a(plugin, change_dir):
@@ -713,7 +712,7 @@ def test_workflow_6a(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_6b(plugin, change_dir):
@@ -744,7 +743,7 @@ def test_workflow_6b(plugin, change_dir):
 
 # tests for a workflow that have its own input
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_7(plugin, change_dir):
@@ -767,7 +766,7 @@ def test_workflow_7(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_7a(plugin, change_dir):
@@ -787,7 +786,7 @@ def test_workflow_7a(plugin, change_dir):
         assert wf.nodes[0].result["out"][i][0] == res[0]
         assert wf.nodes[0].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_8(plugin, change_dir):
@@ -819,7 +818,7 @@ def test_workflow_8(plugin, change_dir):
 
 # testing if _NA in splitter works, using interfaces in add
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_9(plugin, change_dir):
@@ -845,7 +844,7 @@ def test_workflow_9(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_10(plugin, change_dir):
@@ -872,7 +871,7 @@ def test_workflow_10(plugin, change_dir):
         assert wf.nodes[1].result["out"][i][0] == res[0]
         assert wf.nodes[1].result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_10a(plugin, change_dir):
@@ -906,7 +905,6 @@ def test_workflow_10a(plugin, change_dir):
 
 
 # TODO: this test started sometimes failing for mp and cf
-@pytest.mark.skip("WIP")
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_11(plugin, change_dir):
@@ -941,7 +939,7 @@ def test_workflow_11(plugin, change_dir):
 
 # checking workflow.result
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_12(plugin, change_dir):
@@ -977,7 +975,7 @@ def test_workflow_12(plugin, change_dir):
         assert wf.result["out"][i][0] == res[0]
         assert wf.result["out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_12a(plugin, change_dir):
@@ -1001,7 +999,7 @@ def test_workflow_12a(plugin, change_dir):
 
 
 # tests for a workflow that have its own input and splitter
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_13(plugin, change_dir):
@@ -1053,7 +1051,7 @@ def test_workflow_13a(plugin, change_dir):
             assert list(wf.result["NA_out"][i][1].values())[j][0] == res[1][j][0]
             assert list(wf.result["NA_out"][i][1].values())[j][1] == res[1][j][1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_13b(plugin, change_dir):
@@ -1076,7 +1074,7 @@ def test_workflow_13b(plugin, change_dir):
         assert wf.result["NA_out"][i][0] == res[0]
         assert wf.result["NA_out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_13c(plugin, change_dir):
@@ -1098,7 +1096,7 @@ def test_workflow_13c(plugin, change_dir):
         assert wf.result["NA_out"][i][0] == res[0]
         assert wf.result["NA_out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_14(plugin, change_dir):
@@ -1122,7 +1120,7 @@ def test_workflow_14(plugin, change_dir):
         assert wf.result["NA_out"][i][0] == res[0]
         assert wf.result["NA_out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_15(plugin, change_dir):
@@ -1150,7 +1148,7 @@ def test_workflow_15(plugin, change_dir):
 
 
 # workflow as a node
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_16(plugin, change_dir):
@@ -1171,7 +1169,7 @@ def test_workflow_16(plugin, change_dir):
     assert wf.is_complete
     assert wf.result["wfa_out"] == ({}, 5)
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_16a(plugin, change_dir):
@@ -1194,7 +1192,7 @@ def test_workflow_16a(plugin, change_dir):
     assert wf.is_complete
     assert wf.result["wfa_out"] == ({}, 5)
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_16b(plugin, change_dir):
@@ -1216,7 +1214,7 @@ def test_workflow_16b(plugin, change_dir):
     assert wf.is_complete
     assert wf.result["wfa_out"] == ({}, 5)
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_17(plugin, change_dir):
@@ -1240,7 +1238,7 @@ def test_workflow_17(plugin, change_dir):
         assert wf.result["wfa_out"][i][0] == res[0]
         assert wf.result["wfa_out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_18(plugin, change_dir):
@@ -1275,7 +1273,7 @@ def test_workflow_18(plugin, change_dir):
     # the naming should have names with workflows??
     assert wf.result["NB_out"] == ({}, 15)
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_19(plugin, change_dir):
@@ -1322,7 +1320,7 @@ def test_workflow_19(plugin, change_dir):
         assert wf.result["NB_out"][i][0] == res[0]
         assert wf.result["NB_out"][i][1] == res[1]
 
-@pytest.mark.skip("WIP")
+
 @pytest.mark.parametrize("plugin", Plugins)
 @python35_only
 def test_workflow_19a(plugin, change_dir):

--- a/pydra/engine/tests/test_node_combine.py
+++ b/pydra/engine/tests/test_node_combine.py
@@ -35,6 +35,7 @@ def change_dir(request):
 Plugins = ["serial"]
 Plugins = ["serial", "mp", "cf", "dask"]
 
+pytestmark = pytest.mark.skip("WIP")
 
 def fun_addtwo(a):
     import time

--- a/pydra/engine/tests/test_node_combine.py
+++ b/pydra/engine/tests/test_node_combine.py
@@ -7,8 +7,8 @@ from nipype.interfaces import fsl
 from nipype import Function
 
 from ..node import Node, Workflow
-from ..auxiliary import CurrentInterface
 from ..submitter import Submitter
+from ..task import to_task
 
 import pytest
 import pdb
@@ -33,10 +33,10 @@ def change_dir(request):
 
 
 Plugins = ["serial"]
-Plugins = ["serial", "mp", "cf", "dask"]
+#Plugins = ["serial", "mp", "cf", "dask"]
 
-pytestmark = pytest.mark.skip("WIP")
 
+@to_task
 def fun_addtwo(a):
     import time
     time.sleep(1)
@@ -44,50 +44,39 @@ def fun_addtwo(a):
         time.sleep(2)
     return a + 2
 
-_interf_addtwo = Function(function=fun_addtwo, input_names=["a"], output_names=["out"])
-interf_addtwo = CurrentInterface(interface=_interf_addtwo, name="addtwo")
 
-
+@to_task
 def fun_addvar(b, c):
     return b + c
 
-_interf_addvar = Function(function=fun_addvar, input_names=["b", "c"], output_names=["out"])
-interf_addvar = CurrentInterface(interface=_interf_addvar, name="addvar")
 
-
+@to_task
 def fun_addvar3(a, b, c):
     return a + b + c
 
-_interf_addvar3 = Function(function=fun_addvar3, input_names=["a", "b", "c"], output_names=["out"])
-interf_addvar3 = CurrentInterface(interface=_interf_addvar3, name="addvar3")
 
-
+@to_task
 def fun_addvar4(a, b, c, d):
     return a + b + c + d
 
-_interf_addvar4 = Function(function=fun_addvar4, input_names=["a", "b", "c", "d"], output_names=["out"])
-interf_addvar4 = CurrentInterface(interface=_interf_addvar4, name="addvar4")
 
-
+@to_task
 def fun_sumlist(a):
     return sum(a)
-
-_interf_sumlist = Function(function=fun_sumlist, input_names=["a"], output_names=["out"])
-interf_sumlist = CurrentInterface(interface=_interf_sumlist, name="sumlist")
 
 
 # initializing nodes, setting containers
 
 def test_node_combine_1():
     """Node with mandatory arguments only"""
-    nn = Node(name="NA", interface=interf_addtwo)
+    nn = Node(name="NA", interface=fun_addtwo())
     assert nn.splitter is None
     assert nn.combiner == []
 
 
 def test_node_combine_2():
     """Node with interface, inputs and splitter"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]}, splitter="a")
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]}, splitter="a")
     assert nn.splitter == "NA.a"
     assert (nn.inputs["NA.a"] == np.array([3, 5])).all()
     assert nn.splitter == "NA.a"
@@ -96,7 +85,7 @@ def test_node_combine_2():
 
 def test_node_combine_3():
     """Node with interface, inputs, splitter and combiner"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]},
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]},
               splitter="a", combiner="a")
     assert nn.splitter == "NA.a"
     assert (nn.inputs["NA.a"] == np.array([3, 5])).all()
@@ -106,7 +95,7 @@ def test_node_combine_3():
 
 def test_node_combine_3a():
     """Node with interface, inputs, splitter and combiner (with node name)"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]},
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]},
               splitter="a", combiner="NA.a")
     assert nn.splitter == "NA.a"
     assert (nn.inputs["NA.a"] == np.array([3, 5])).all()
@@ -117,7 +106,7 @@ def test_node_combine_3a():
 def test_node_combine_3b():
     """Node with interface, inputs and combiner (without splitter)"""
     with pytest.raises(Exception) as excinfo:
-        nn = Node(name="NA", interface=interf_addtwo, inputs={"a": 3},
+        nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": 3},
                   combiner="a")
     assert str(excinfo.value) ==\
            "splitter has to be set before setting combiner"
@@ -125,7 +114,7 @@ def test_node_combine_3b():
 
 def test_node_combine_4():
     """Node with interface,  two inputs, splitter and combiner"""
-    nn = Node(name="NA", interface=interf_addvar,
+    nn = Node(name="NA", interface=fun_addvar(),
               inputs={"a": [3, 5], "b": [10, 20]},
               splitter=["a", "b"], combiner=["a", "b"])
     assert nn.splitter == ["NA.a", "NA.b"]
@@ -139,7 +128,7 @@ def test_node_combine_4a():
     """Node with interface,  two inputs, splitter and combiner
         (different order for combiner)
     """
-    nn = Node(name="NA", interface=interf_addvar,
+    nn = Node(name="NA", interface=fun_addvar(),
               inputs={"a": [3, 5], "b": [10, 20]},
               splitter=["a", "b"], combiner=["b", "a"])
     assert nn.splitter == ["NA.a", "NA.b"]
@@ -151,7 +140,7 @@ def test_node_combine_4a():
 
 def test_node_combine_5():
     """Node with interface, inputs, splitter, combiner set later"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]},
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]},
               splitter="a")
     nn.combiner = "a"
     assert nn.splitter == "NA.a"
@@ -160,7 +149,7 @@ def test_node_combine_5():
 
 def test_node_combine_5a():
     """Node with interface, inputs, splitter, combiner set later (using node name)"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]},
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]},
               splitter="a")
     nn.combiner = "NA.a"
     assert nn.splitter == "NA.a"
@@ -169,7 +158,7 @@ def test_node_combine_5a():
 
 def test_node_combine_5b():
     """Node with interface, inputs, splitter, setting combiner twice"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]},
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]},
               splitter="a", combiner="a")
     with pytest.raises(Exception) as excinfo:
         nn.combiner = "a"
@@ -178,7 +167,7 @@ def test_node_combine_5b():
 
 def test_node_combine_6():
     """Node with interface, inputs, splitter, combiner set by combine method"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]},
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]},
               splitter="a")
     nn.combine(combiner="a")
     assert nn.splitter == "NA.a"
@@ -187,7 +176,7 @@ def test_node_combine_6():
 
 def test_node_combine_6a():
     """Node with interface, inputs, splitter and combiner set in one chain"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]})
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]})
     nn.split(splitter="a").combine(combiner="a")
     assert nn.splitter == "NA.a"
     assert nn.combiner == ["NA.a"]
@@ -195,7 +184,7 @@ def test_node_combine_6a():
 
 def test_node_combine_6b():
     """Node with interface, inputs, splitter, setting combiner twice"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]},
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]},
               splitter="a", combiner="a")
     with pytest.raises(Exception) as excinfo:
         nn.combine(combiner="a")
@@ -204,7 +193,7 @@ def test_node_combine_6b():
 
 def test_node_combine_6c():
     """Node with interface, inputs, combiner set by combine method (no splitter)"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]})
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]})
     with pytest.raises(Exception) as excinfo:
         nn.combine(combiner="a")
     assert str(excinfo.value) ==\
@@ -215,7 +204,7 @@ def test_node_combine_6c():
 @python35_only
 def test_node_combine_7(plugin, change_dir):
     """Node with interface, inputs, combiner set by combine method (no splitter)"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]}, splitter="a")
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]}, splitter="a")
     with pytest.raises(Exception) as excinfo:
         nn.combine(combiner="b")
         sub = Submitter(plugin=plugin, runnable=nn)
@@ -229,7 +218,7 @@ def test_node_combine_7(plugin, change_dir):
 
 def test_node_combine_8():
     """Node with interface, inputs, splitter and combiner"""
-    nn = Node(name="NA", interface=interf_addtwo, inputs={"a": [3, 5]},
+    nn = Node(name="NA", interface=fun_addtwo(), inputs={"a": [3, 5]},
               splitter="a", combiner="a")
     assert nn.splitter == "NA.a"
     assert nn.combiner == ["NA.a"]
@@ -240,7 +229,7 @@ def test_node_combine_8():
 
 def test_node_combine_9():
     """Node with interface,  two inputs, splitter and combiner"""
-    nn = Node(name="NA", interface=interf_addvar,
+    nn = Node(name="NA", interface=fun_addvar(),
               inputs={"a": [3, 5], "b": [10, 20]},
               splitter=["a", "b"], combiner=["a", "b"])
     assert nn.splitter == ["NA.a", "NA.b"]
@@ -255,7 +244,7 @@ def test_node_combine_9():
 @python35_only
 def test_node_combine_10(plugin, change_dir):
     """simplest combiner in init, running the node"""
-    nn = Node(name="NA", interface=interf_addtwo, workingdir="test_nd10_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addtwo(), workingdir="test_nd10_{}".format(plugin),
               output_names=["out"], splitter="a", combiner="a", inputs={"a": [3, 5]})
 
     assert nn.splitter == "NA.a"
@@ -273,7 +262,7 @@ def test_node_combine_10(plugin, change_dir):
 @python35_only
 def test_node_combine_10a(plugin, change_dir):
     """simplest combiner by combine, running the node"""
-    nn = Node(name="NA", interface=interf_addtwo, workingdir="test_nd10a_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addtwo(), workingdir="test_nd10a_{}".format(plugin),
               output_names=["out"], inputs={"a": [3, 5]})
     nn.split(splitter="a").combine(combiner="a")
     assert nn.splitter == "NA.a"
@@ -291,7 +280,7 @@ def test_node_combine_10a(plugin, change_dir):
 @python35_only
 def test_node_combine_10b(plugin, change_dir):
     """simplest combiner in init, running the node"""
-    nn = Node(name="NA", interface=interf_addtwo, workingdir="test_nd10b_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addtwo(), workingdir="test_nd10b_{}".format(plugin),
               output_names=["out"], splitter="a", inputs={"a": [3, 5]})
     nn.combiner = "a"
 
@@ -310,7 +299,7 @@ def test_node_combine_10b(plugin, change_dir):
 @python35_only
 def test_node_combine_11(plugin, change_dir):
     """Node with interface, inputs and scalar splitter, running interface"""
-    nn = Node(name="NA", interface=interf_addvar, workingdir="test_nd11_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar(), workingdir="test_nd11_{}".format(plugin),
               output_names=["out"], splitter=("b", "c"), combiner="b",
               inputs={"b": [3, 5], "c": [2, 1]})
 
@@ -332,7 +321,7 @@ def test_node_combine_11a(plugin, change_dir):
     trying to combine with both elements of scalar splitter
     """
     with pytest.raises(Exception) as excinfo:
-        nn = Node(name="NA", interface=interf_addvar, workingdir="test_nd11a_{}".format(plugin),
+        nn = Node(name="NA", interface=fun_addvar(), workingdir="test_nd11a_{}".format(plugin),
                   output_names=["out"], splitter=("b", "c"), combiner=["b", "c"],
                   inputs={"b": [3, 5], "c": [2, 1]})
         sub = Submitter(plugin=plugin, runnable=nn)
@@ -345,7 +334,7 @@ def test_node_combine_11a(plugin, change_dir):
 @python35_only
 def test_node_combine_12(plugin, change_dir):
     """Node with interface, inputs and vector splitter, running interface"""
-    nn = Node(name="NA", interface=interf_addvar, workingdir="test_nd12_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar(), workingdir="test_nd12_{}".format(plugin),
               output_names=["out"], splitter=["b", "c"], combiner="b",
               inputs={"b": [3, 5], "c": [2, 1]})
 
@@ -369,7 +358,7 @@ def test_node_combine_12(plugin, change_dir):
 @python35_only
 def test_node_combine_13(plugin, change_dir):
     """two outer splitters, one combiner"""
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd13_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd13_{}".format(plugin),
               output_names=["out"], splitter=["a", ["b", "c"]], combiner="a",
               inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
 
@@ -392,7 +381,7 @@ def test_node_combine_13(plugin, change_dir):
 @python35_only
 def test_node_combine_13a(plugin, change_dir):
     """two outer splitters, two combiners"""
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd13a_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd13a_{}".format(plugin),
               output_names=["out"], splitter=["a", ["b", "c"]], combiner=["a", "b"],
               inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
 
@@ -414,7 +403,7 @@ def test_node_combine_13a(plugin, change_dir):
 @python35_only
 def test_node_combine_13b(plugin, change_dir):
     """two outer splitters, three combiners"""
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd13b_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd13b_{}".format(plugin),
               output_names=["out"], splitter=["a", ["b", "c"]], combiner=["a", "b", "c"],
               inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
 
@@ -433,7 +422,7 @@ def test_node_combine_13b(plugin, change_dir):
 @python35_only
 def test_node_combine_14(plugin, change_dir):
     """outer and scalar splitter, one combiner (from outer part)"""
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd14_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd14_{}".format(plugin),
               output_names=["out"], splitter=["a", ("b", "c")], combiner="a",
               inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
 
@@ -455,7 +444,7 @@ def test_node_combine_14(plugin, change_dir):
 @python35_only
 def test_node_combine_14a(plugin, change_dir):
     """outer and scalar splitter, two combiners (one from outer and one from scalar part)"""
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd14a_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd14a_{}".format(plugin),
               output_names=["out"], splitter=["a", ("b", "c")], combiner=["a", "b"],
               inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
 
@@ -474,7 +463,7 @@ def test_node_combine_14a(plugin, change_dir):
 @python35_only
 def test_node_combine_14b(plugin, change_dir):
     """outer and scalar splitter, two combiners (second one from scalar part - should be the same)"""
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd14b_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd14b_{}".format(plugin),
               output_names=["out"], splitter=["a", ("b", "c")], combiner=["a", "c"],
               inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
 
@@ -494,7 +483,7 @@ def test_node_combine_14b(plugin, change_dir):
 def test_node_combine_14c(plugin, change_dir):
     """outer and scalar splitter, two combiners (second one from scalar part - should be the same)"""
     with pytest.raises(Exception) as excinfo:
-        nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd14c_{}".format(plugin),
+        nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd14c_{}".format(plugin),
                   output_names=["out"], splitter=["a", ("b", "c")], combiner=["a", "b", "c"],
                   inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
         sub = Submitter(plugin=plugin, runnable=nn)
@@ -507,7 +496,7 @@ def test_node_combine_14c(plugin, change_dir):
 @python35_only
 def test_node_combine_14d(plugin, change_dir):
     """outer and scalar splitter, one combiner (from outer part)"""
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd14d_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd14d_{}".format(plugin),
               output_names=["out"], splitter=["a", ("b", "c")], combiner="b",
               inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
 
@@ -530,7 +519,7 @@ def test_node_combine_14d(plugin, change_dir):
 def test_node_combine_14e(plugin, change_dir):
     """outer and scalar splitter, two combiners (second one from scalar part - should be the same)"""
     with pytest.raises(Exception) as excinfo:
-        nn = Node(name="NA", interface=interf_addvar3, output_names=["out"],
+        nn = Node(name="NA", interface=fun_addvar3(), output_names=["out"],
                   workingdir="test_nd14e_{}".format(plugin),
                   splitter=["a", ("b", "c")], combiner=["b", "c"],
                   inputs={"a": [1, 2, 3], "b": [1, 2], "c": [1, 2]})
@@ -544,7 +533,7 @@ def test_node_combine_14e(plugin, change_dir):
 @python35_only
 def test_node_combine_15(plugin, change_dir):
     """scalar and outer splitter, one combiner (from scalar part)"""
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd15_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd15_{}".format(plugin),
               output_names=["out"], splitter=("a", ["b", "c"]), combiner="a",
               inputs={"a": [[11, 12], [21, 22]], "b": [1, 2], "c": [1, 2]})
 
@@ -564,7 +553,7 @@ def test_node_combine_15(plugin, change_dir):
 def test_node_combine_15a(plugin, change_dir):
     """scalar and outer splitter, two combiners (from scalar and outer parts)"""
     with pytest.raises(Exception) as excinfo:
-        nn = Node(name="NA", interface=interf_addvar3, output_names=["out"],
+        nn = Node(name="NA", interface=fun_addvar3(), output_names=["out"],
                   workingdir="test_nd15a_{}".format(plugin),
                   splitter=("a", ["b", "c"]), combiner=["a", "b"],
                   inputs={"a": [[11, 12], [21, 22]], "b": [1, 2], "c": [1, 2]})
@@ -580,7 +569,7 @@ def test_node_combine_15b(plugin, change_dir):
     """scalar and outer splitter, one combiner (from outer part)
     We assumed that this is OK, but will eliminate also a
     """
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd15b_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd15b_{}".format(plugin),
               output_names=["out"], splitter=("a", ["b", "c"]), combiner="b",
               inputs={"a": [[11, 12], [21, 22]], "b": [1, 2], "c": [1, 2]})
 
@@ -604,7 +593,7 @@ def test_node_combine_15c(plugin, change_dir):
     """scalar and outer splitter, one combiner (from outer part)
     We assumed that this is OK, but will eliminate also a
     """
-    nn = Node(name="NA", interface=interf_addvar3, workingdir="test_nd15c_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar3(), workingdir="test_nd15c_{}".format(plugin),
               output_names=["out"], splitter=("a", ["b", "c"]), combiner="c",
               inputs={"a": [[11, 12], [21, 22]], "b": [1, 2], "c": [1, 2]})
 
@@ -629,7 +618,7 @@ def test_node_combine_15d(plugin, change_dir):
     We assumed that this is OK, but will eliminate also a
     """
     with pytest.raises(Exception) as excinfo:
-        nn = Node(name="NA", interface=interf_addvar3, output_names=["out"],
+        nn = Node(name="NA", interface=fun_addvar3(), output_names=["out"],
                   workingdir="test_nd15d_{}".format(plugin),
                   splitter=("a", ["b", "c"]), combiner=["c", "a"],
                   inputs={"a": [[11, 12], [21, 22]], "b": [1, 2], "c": [1, 2]})
@@ -643,7 +632,7 @@ def test_node_combine_15d(plugin, change_dir):
 @python35_only
 def test_node_combine_16(plugin, change_dir):
     """scalar and outer splitter, one combiner"""
-    nn = Node(name="NA", interface=interf_addvar4, workingdir="test_nd16_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar4(), workingdir="test_nd16_{}".format(plugin),
               output_names=["out"], splitter=(["a", "b"], ["c", "d"]), combiner="a",
               inputs={"a": [1, 2], "b": [1, 2], "c": [1, 2], "d": [1, 2]})
 
@@ -665,7 +654,7 @@ def test_node_combine_16(plugin, change_dir):
 @python35_only
 def test_node_combine_16a(plugin, change_dir):
     """scalar and outer splitter, two combiners"""
-    nn = Node(name="NA", interface=interf_addvar4, workingdir="test_nd16a_{}".format(plugin),
+    nn = Node(name="NA", interface=fun_addvar4(), workingdir="test_nd16a_{}".format(plugin),
               output_names=["out"], splitter=(["a", "b"], ["c", "d"]), combiner=["a", "b"],
               inputs={"a": [1, 2], "b": [1, 2], "c": [1, 2], "d": [1, 2]})
 
@@ -685,7 +674,7 @@ def test_node_combine_16a(plugin, change_dir):
 def test_node_combine_16b(plugin, change_dir):
     """scalar and outer splitter, two combiner from the same axis (exception)"""
     with pytest.raises(Exception) as excinfo:
-        nn = Node(name="NA", interface=interf_addvar4, output_names=["out"],
+        nn = Node(name="NA", interface=fun_addvar4(), output_names=["out"],
                   workingdir="test_nd16b_{}".format(plugin),
                   splitter=(["a", "b"], ["c", "d"]), combiner=["a", "c"],
                   inputs={"a": [1, 2], "b": [1, 2], "c": [1, 2], "d": [1,2]})
@@ -703,7 +692,7 @@ def test_workflow_combine_0(plugin="serial"):
     """workflow (without run) with one node with a splitter"""
     wf = Workflow(name="wf0", workingdir="test_wf0_{}".format(plugin))
     # defining a node with splitter and inputs first
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["a"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["a"])
     na.split(splitter="a", inputs={"a": [3, 5]}).combine(combiner="a")
     # one of the way of adding nodes to the workflow
     wf.add_nodes([na])
@@ -719,7 +708,7 @@ def test_workflow_combine_1(plugin, change_dir):
     """workflow with one node with a splitter and a combiner"""
     wf = Workflow(name="wf1", workingdir="test_wf1_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"],
               splitter="a", combiner="a", inputs={"a": [3, 5]})
     wf.add_nodes([na])
 
@@ -741,7 +730,7 @@ def test_workflow_combine_1a(plugin, change_dir):
     """workflow with one node with a splitter and a combiner (checking results of the wf)"""
     wf = Workflow(name="wf1", workingdir="test_wf1a_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     na.split(splitter="a", inputs={"a": [3, 5]}).combine(combiner="a")
     wf.add_nodes([na])
 
@@ -763,11 +752,11 @@ def test_workflow_combine_2(plugin, change_dir):
     """workflow with two nodes, first one with splitter and combiner"""
     wf = Workflow(name="wf2", workingdir="test_wf2_{}".format(plugin),
                   wf_output_names=[("NB", "out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     na.split(splitter="a", inputs={"a": [3, 5]}).combine(combiner="a")
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
 
     # adding 2 nodes and create a connection (as it is now)
     wf.add_nodes([na, nb])
@@ -792,11 +781,11 @@ def test_workflow_combine_3(plugin, change_dir):
     """workflow with two nodes, first one with splitter and combiner (different than splitter)"""
     wf = Workflow(name="wf3", workingdir="test_wf3_{}".format(plugin),
                   wf_output_names=[("NB", "out"), ("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addvar, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar(), workingdir="na", output_names=["out"])
     na.split(splitter=["b", "c"], inputs={"b": [3, 5, 7], "c": [10, 20]}).combine(combiner="b")
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
 
     # adding 2 nodes and create a connection (as it is now)
     wf.add_nodes([na, nb])
@@ -831,11 +820,11 @@ def test_workflow_combine_3a(plugin, change_dir):
     """workflow with two nodes, first one with splitter and combiner (different than splitter)"""
     wf = Workflow(name="wf3a", workingdir="test_wf3a_{}".format(plugin),
                   wf_output_names=[("NB", "out")])
-    na = Node(name="NA", interface=interf_addvar, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar(), workingdir="na", output_names=["out"])
     na.split(splitter=["b", "c"], inputs={"b": [3, 5, 7], "c": [10, 20]}).combine(combiner="c")
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
 
     # adding 2 nodes and create a connection (as it is now)
     wf.add_nodes([na, nb])
@@ -870,11 +859,11 @@ def test_workflow_combine_3b(plugin, change_dir):
     """workflow with two nodes, first one with splitter and combiner (both axes)"""
     wf = Workflow(name="wf3b", workingdir="test_wf3b_{}".format(plugin),
                   wf_output_names=[("NB", "out")])
-    na = Node(name="NA", interface=interf_addvar, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar(), workingdir="na", output_names=["out"])
     na.split(splitter=["b", "c"], inputs={"b": [3, 5, 7], "c": [10, 20]}).combine(combiner=["b", "c"])
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
 
     # adding 2 nodes and create a connection (as it is now)
     wf.add_nodes([na, nb])
@@ -901,10 +890,10 @@ def test_workflow_combine_4(plugin, change_dir):
         splitter in two nodes, combiner in the second
     """
     wf = Workflow(name="wf4", workingdir="test_wf4_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     na.split(splitter="a", inputs={"a": [3, 5]})
     wf.add(na)
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # explicit splitter with a variable from the previous node
     # providing inputs with b
     nb.split(splitter=("NA.a", "c"), inputs={"c": [2, 1]}).combine(combiner="c")
@@ -932,7 +921,7 @@ def test_workflow_combine_4(plugin, change_dir):
 def test_workflow_combine_5(plugin, change_dir):
     """using split_node and combiner_node methods for one node"""
     wf = Workflow(name="wf5", workingdir="test_wf5_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
     wf.add(na)
     # using the split_node method after add (using splitter for the last added node as default)
@@ -951,7 +940,7 @@ def test_workflow_combine_5(plugin, change_dir):
 def test_workflow_combine_5a(plugin, change_dir):
     """using split_node and combine_node methods for one node in one chain"""
     wf = Workflow(name="wf5a", workingdir="test_wf5a_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
     wf.add(na).split_node(splitter="a", inputs={"a": [3, 5]}).combine_node(combiner="a")
 
@@ -967,9 +956,9 @@ def test_workflow_combine_5a(plugin, change_dir):
 def test_workflow_combine_6(plugin, change_dir):
     """using split_node and combine_node methods for two nodes (using last added node as default)"""
     wf = Workflow(name="wf6", workingdir="test_wf6_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # using the split methods after add (using splitter for the last added nodes as default)
     wf.add(na)
     wf.split_node(splitter="a", inputs={"a": [3, 5]})
@@ -994,9 +983,9 @@ def test_workflow_combine_6(plugin, change_dir):
 def test_workflow_combine_6a(plugin, change_dir):
     """using split_node and combine_node methods for two nodes (specifying the node)"""
     wf = Workflow(name="wf6a", workingdir="test_wf6a_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # using the split method after add (specifying the node)
     wf.add(na)
     wf.add(nb)
@@ -1025,8 +1014,8 @@ def test_workflow_combine_6b(plugin, change_dir):
     using kwarg arg instead of connect
     """
     wf = Workflow(name="wf6b", workingdir="test_wf6b_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
 
     wf.add(na)
     wf.add(nb, b="NA.out")
@@ -1055,9 +1044,9 @@ def test_workflow_combine_7(plugin, change_dir):
         using combiner from previous node, scalar splitter
     """
     wf = Workflow(name="wf7", workingdir="test_wf7_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # using the split methods after add (using splitter for the last added nodes as default)
     wf.add(na)
     wf.split_node(splitter="a", inputs={"a": [3, 5]})
@@ -1084,9 +1073,9 @@ def test_workflow_combine_7a(plugin, change_dir):
         using combiner from previous node, outer splitter
     """
     wf = Workflow(name="wf7a", workingdir="test_wf7a_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
-    nb = Node(name="NB", interface=interf_addvar, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addvar(), workingdir="nb", output_names=["out"])
     # using the split methods after add (using splitter for the last added nodes as default)
     wf.add(na)
     wf.split_node(splitter="a", inputs={"a": [3, 5]})
@@ -1117,12 +1106,12 @@ def test_workflow_combine_8(plugin, change_dir):
     """workflow with two nodes, first one with splitter and combiner (different than splitter)"""
     wf = Workflow(name="wf8", workingdir="test_wf8_{}".format(plugin),
                   wf_output_names=[("NB", "out")])
-    na = Node(name="NA", interface=interf_addvar3, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar3(), workingdir="na", output_names=["out"])
     na.split(splitter=[("a", "b"), "c"], inputs={"a": [1, 2], "b": [3, 5], "c": [10, 20, 30]})\
         .combine(combiner="b")
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
 
     # adding 2 nodes and create a connection (as it is now)
     wf.add_nodes([na, nb])
@@ -1160,13 +1149,13 @@ def test_workflow_combine_9(plugin, change_dir):
     """
     wf = Workflow(name="wf9", workingdir="test_wf9_{}".format(plugin),
                   wf_output_names=[("NB", "out"), ("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addvar3, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar3(), workingdir="na", output_names=["out"])
     na.split(splitter=(["a", "b"], "c"), inputs={"a": [1, 2], "b": [3, 5, 7],
                                                  "c": [[10, 20, 30], [100, 200, 300]]})\
         .combine(combiner="a")
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
 
     # adding 2 nodes and create a connection (as it is now)
     wf.add_nodes([na, nb])
@@ -1205,13 +1194,13 @@ def test_workflow_combine_9a(plugin, change_dir):
     """
     wf = Workflow(name="wf9a", workingdir="test_wf9a_{}".format(plugin),
                   wf_output_names=[("NB", "out")])
-    na = Node(name="NA", interface=interf_addvar3, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar3(), workingdir="na", output_names=["out"])
     na.split(splitter=(["a", "b"], "c"), inputs={"a": [1, 2], "b": [3, 5, 7],
                                                  "c": [[10, 20, 30], [100, 200, 300]]})\
         .combine(combiner="b")
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
 
     # adding 2 nodes and create a connection (as it is now)
     wf.add_nodes([na, nb])
@@ -1250,13 +1239,13 @@ def test_workflow_combine_9b(plugin, change_dir):
     """
     wf = Workflow(name="wf9b", workingdir="test_wf9b_{}".format(plugin),
                   wf_output_names=[("NB", "out")])
-    na = Node(name="NA", interface=interf_addvar3, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar3(), workingdir="na", output_names=["out"])
     na.split(splitter=(["a", "b"], "c"), inputs={"a": [1, 2], "b": [3, 5, 7],
                                                  "c": [[10, 20, 30], [100, 200, 300]]})\
         .combine(combiner="c")
 
     # the second node does not have explicit splitter (but keeps the splitter from the NA node)
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
 
     # adding 2 nodes and create a connection (as it is now)
     wf.add_nodes([na, nb])
@@ -1287,7 +1276,7 @@ def test_workflow_combine_10(plugin, change_dir):
     """using inputs for workflow and connect_workflow"""
     # adding inputs to the workflow directly
     wf = Workflow(name="wf10", inputs={"wfa": [3, 5]}, workingdir="test_wf10_{}".format(plugin))
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
 
     wf.add(na)
     # connecting the node with inputs from the workflow
@@ -1311,10 +1300,10 @@ def test_workflow_combine_11(plugin, change_dir):
         combiner in the second node
     """
     wf = Workflow(name="wf11", workingdir="test_wf11_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addtwo, workingdir="na",
+    wf.add(name="NA", runnable=fun_addtwo(), workingdir="na",
            output_names=["out"]).split_node(splitter="a", inputs={"a": [3, 5]})
     # _NA means that I'm using splitter from the NA node, it's the same as ("NA.a", "b")
-    wf.add(name="NB", runnable=interf_addvar, workingdir="nb", b="NA.out",
+    wf.add(name="NB", runnable=fun_addvar(), workingdir="nb", b="NA.out",
            output_names=["out"]).split_node(splitter=("_NA", "c"), inputs={"c": [2, 1]})\
         .combine_node(combiner="c")
 
@@ -1335,11 +1324,11 @@ def test_workflow_combine_11(plugin, change_dir):
 def test_workflow_combine_12(plugin, change_dir):
     """scalar splitter from previous nodes and combiner field from previous node"""
     wf = Workflow(name="wf12", workingdir="test_wf12_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addvar, workingdir="na",
+    wf.add(name="NA", runnable=fun_addvar(), workingdir="na",
            output_names=["out"]).split_node(
         splitter=("b", "c"), inputs={"b": [3, 5], "c": [0, 10]})
     # _NA means that I'm using splitter from the NA node, it's the same as (("NA.a", NA.b), "b")
-    wf.add(name="NB", runnable=interf_addvar, workingdir="nb", b="NA.out",
+    wf.add(name="NB", runnable=fun_addvar(), workingdir="nb", b="NA.out",
            output_names=["out"]).split_node(splitter=("_NA", "c"), inputs={"c": [2, 1]})\
         .combine_node("NA.b")
 
@@ -1361,11 +1350,11 @@ def test_workflow_combine_12(plugin, change_dir):
 def test_workflow_combine_12a(plugin, change_dir):
     """vector splitter from previous nodes and combiner field from previous node"""
     wf = Workflow(name="wf12a", workingdir="test_wf12a_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addvar, workingdir="na",
+    wf.add(name="NA", runnable=fun_addvar(), workingdir="na",
            output_names=["out"]).split_node(
             splitter=["b", "c"], inputs={"b": [3, 5], "c": [0, 10]})
     # _NA means that I'm using splitter from the NA node, it's the same as (["NA.a", NA.b], "b")
-    wf.add(name="NB", runnable=interf_addvar, workingdir="nb", b="NA.out",
+    wf.add(name="NB", runnable=fun_addvar(), workingdir="nb", b="NA.out",
            output_names=["out"]).split_node(
             splitter=("_NA", "c"), inputs={"c": [[2, 1], [0, 0]]})\
         .combine_node(combiner="NA.b")
@@ -1392,13 +1381,13 @@ def test_workflow_combine_12a(plugin, change_dir):
 def test_workflow_combine_13(plugin, change_dir):
     """vector splitter from previous two nodes and combiner from one of the nodes"""
     wf = Workflow(name="wf13", workingdir="test_wf13_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addvar, workingdir="na",
+    wf.add(name="NA", runnable=fun_addvar(), workingdir="na",
            output_names=["out"]).split_node(
             splitter=("b", "c"), inputs={"b": [3, 5],"c": [0, 10]})
-    wf.add(name="NB", runnable=interf_addtwo, workingdir="nb",
+    wf.add(name="NB", runnable=fun_addtwo(), workingdir="nb",
            output_names=["out"]).split_node(splitter="a", inputs={"a": [2, 1]})
     # _NA, _NB means that I'm using splitters from the NA/NB nodes, it's the same as [("NA.a", NA.b), "NB.a"]
-    wf.add(name="NC", runnable=interf_addvar, workingdir="nc", b="NA.out", c="NB.out",
+    wf.add(name="NC", runnable=fun_addvar(), workingdir="nc", b="NA.out", c="NB.out",
            output_names=["out"]).split_node(splitter=["_NA", "_NB"]).combine_node(combiner=["NA.b"])
 
     sub = Submitter(runnable=wf, plugin=plugin)
@@ -1425,13 +1414,13 @@ def test_workflow_combine_13(plugin, change_dir):
 def test_workflow_combine_13a(plugin, change_dir):
     """vector splitter from previous two nodes and combiner from one of the nodes"""
     wf = Workflow(name="wf13a", workingdir="test_wf13a_{}".format(plugin))
-    wf.add(name="NA", runnable=interf_addvar, workingdir="na",
+    wf.add(name="NA", runnable=fun_addvar(), workingdir="na",
            output_names=["out"]).split_node(
             splitter=("b", "c"), inputs={"b": [3, 5],"c": [0, 10]})
-    wf.add(name="NB", runnable=interf_addtwo, workingdir="nb",
+    wf.add(name="NB", runnable=fun_addtwo(), workingdir="nb",
            output_names=["out"]).split_node(splitter="a", inputs={"a": [2, 1]})
     # _NA, _NB means that I'm using splitters from the NA/NB nodes, it's the same as [("NA.a", NA.b), "NB.a"]
-    wf.add(name="NC", runnable=interf_addvar, workingdir="nc", b="NA.out", c="NB.out",
+    wf.add(name="NC", runnable=fun_addvar(), workingdir="nc", b="NA.out", c="NB.out",
            output_names=["out"]).split_node(splitter=["_NA", "_NB"]).combine_node(combiner=["NA.b", "NB.a"])
 
     sub = Submitter(runnable=wf, plugin=plugin)
@@ -1455,7 +1444,7 @@ def test_workflow_combine_14(plugin, change_dir):
     wf = Workflow(name="wf14", inputs={"wfa": [3, 5]}, splitter="wfa",
         workingdir="test_wf14_{}".format(plugin), combiner="wfa",
         wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_addtwo, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addtwo(), workingdir="na", output_names=["out"])
     wf.add(na)
     wf.connect_wf_input("wfa", "NA", "a")
 
@@ -1474,7 +1463,7 @@ def test_workflow_combine_15(plugin, change_dir):
     wf = Workflow(name="wf15", inputs={"wfb": [3, 5], "wfc": [10, 20]},
                   splitter=("wfb", "wfc"), workingdir="test_wf15_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out")], combiner="wfb")
-    na = Node(name="NA", interface=interf_addvar, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar(), workingdir="na", output_names=["out"])
     wf.add(na)
     wf.connect_wf_input("wfb", "NA", "b")
     wf.connect_wf_input("wfc", "NA", "c")
@@ -1494,7 +1483,7 @@ def test_workflow_combine_16(plugin, change_dir):
     wf = Workflow(name="wf16", inputs={"wfb": [3, 5], "wfc": [10, 20]},
                   splitter=["wfb", "wfc"], workingdir="test_wf16_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out")], combiner="wfb")
-    na = Node(name="NA", interface=interf_addvar, workingdir="na", output_names=["out"])
+    na = Node(name="NA", interface=fun_addvar(), workingdir="na", output_names=["out"])
     wf.add(na)
     wf.connect_wf_input("wfb", "NA", "b")
     wf.connect_wf_input("wfc", "NA", "c")

--- a/pydra/engine/tests/test_node_inner.py
+++ b/pydra/engine/tests/test_node_inner.py
@@ -31,6 +31,7 @@ def change_dir(request):
 Plugins = ["serial"]
 Plugins = ["serial", "mp", "cf", "dask"]
 
+pytestmark = pytest.mark.skip("WIP")
 
 def fun_addtwo(a):
     import time

--- a/pydra/engine/tests/test_node_inner.py
+++ b/pydra/engine/tests/test_node_inner.py
@@ -7,8 +7,8 @@ from nipype.interfaces import fsl
 from nipype import Function
 
 from ..node import Node, Workflow
-from ..auxiliary import CurrentInterface
 from ..submitter import Submitter
+from ..task import to_task
 
 import pytest
 import pdb
@@ -29,10 +29,10 @@ def change_dir(request):
 
 
 Plugins = ["serial"]
-Plugins = ["serial", "mp", "cf", "dask"]
+#Plugins = ["serial", "mp", "cf", "dask"]
 
-pytestmark = pytest.mark.skip("WIP")
 
+@to_task
 def fun_addtwo(a):
     import time
     time.sleep(1)
@@ -40,43 +40,26 @@ def fun_addtwo(a):
         time.sleep(2)
     return a + 2
 
-_interf_addtwo = Function(function=fun_addtwo, input_names=["a"], output_names=["out"])
-interf_addtwo = CurrentInterface(interface=_interf_addtwo, name="addtwo")
-
-
+@to_task
 def fun_addvar(b, c):
     return b + c
 
-_interf_addvar = Function(function=fun_addvar, input_names=["b", "c"], output_names=["out"])
-interf_addvar = CurrentInterface(interface=_interf_addvar, name="addvar")
-
-
+@to_task
 def fun_expans(a):
     return list(range(int(a)))
 
-_interf_expans = Function(function=fun_expans, input_names=["a"], output_names=["out"])
-interf_expans = CurrentInterface(interface=_interf_expans, name="expans")
-
-
+@to_task
 def fun_sumlist(el_list):
     return sum(el_list)
 
-_interf_sumlist = Function(function=fun_sumlist, input_names=["el_list"], output_names=["out"])
-interf_sumlist = CurrentInterface(interface=_interf_sumlist, name="sumlist")
-
-
+@to_task
 def fun_list_generator(n):
     return list(range(n))
 
-_interf_list_generator = Function(function=fun_list_generator, input_names=["n"], output_names=["out"])
-interf_list_generator = CurrentInterface(interface=_interf_list_generator, name="list_generator")
-
-
+@to_task
 def fun_list_generator_10(n):
     return list(range(10, 10+n))
 
-_interf_list_generator_10 = Function(function=fun_list_generator_10, input_names=["n"], output_names=["out"])
-interf_list_generator_10 = CurrentInterface(interface=_interf_list_generator_10, name="list_generator")
 
 
 # tests with nodes (or workflows with the nodes) that returns a list (length depends on the input)
@@ -85,7 +68,7 @@ interf_list_generator_10 = CurrentInterface(interface=_interf_list_generator_10,
 @python35_only
 def test_inner_1(change_dir, plugin):
     """Node with interface that returns a list"""
-    nn = Node(name="NA", interface=interf_list_generator, inputs={"n": 3},
+    nn = Node(name="NA", interface=fun_list_generator(), inputs={"n": 3},
               workingdir="test_inner1_{}".format(plugin), output_names=["out"])
     assert nn.inputs["NA.n"] == 3
 
@@ -100,7 +83,7 @@ def test_inner_1(change_dir, plugin):
 @python35_only
 def test_inner_2(change_dir, plugin):
     """Node with interface that returns a list, a simple splitter"""
-    nn = Node(name="NA", interface=interf_list_generator, inputs={"n": [3, 5]},
+    nn = Node(name="NA", interface=fun_list_generator(), inputs={"n": [3, 5]},
               workingdir="test_inner2_{}".format(plugin), output_names=["out"])
     nn.split(splitter="n")
     assert (nn.inputs["NA.n"] == [3, 5]).all()
@@ -119,7 +102,7 @@ def test_inner_2(change_dir, plugin):
 @python35_only
 def test_inner_3(change_dir, plugin):
     """Node with interface that returns a list, a simple splitter and combiner"""
-    nn = Node(name="NA", interface=interf_list_generator, inputs={"n": [3, 5]},
+    nn = Node(name="NA", interface=fun_list_generator(), inputs={"n": [3, 5]},
               workingdir="test_inner2_{}".format(plugin), output_names=["out"])
     nn.split(splitter="n")
     nn.combine(combiner="n")
@@ -138,7 +121,7 @@ def test_innerwf_1(change_dir, plugin):
     """wf with a single nd with an interface that returns a list"""
     wf = Workflow(name="wf1", workingdir="test_innerwf1_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": 3})
     wf.add_nodes([na])
 
@@ -157,7 +140,7 @@ def test_innerwf_2(change_dir, plugin):
     """wf with a single nd with an interface that returns a list, a simple splitter"""
     wf = Workflow(name="wf2", workingdir="test_innerwf2_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": [3, 5]}, splitter="n")
     wf.add_nodes([na])
 
@@ -184,9 +167,9 @@ def test_innerwf_3(change_dir, plugin):
     """
     wf = Workflow(name="wf3", workingdir="test_innerwf3_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NB", "out", "NB_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": 3})
-    nb = Node(name="NB", interface=interf_sumlist, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_sumlist(), workingdir="nb", output_names=["out"])
     wf.add_nodes([na, nb])
     wf.connect("NA", "out", "NB", "el_list")
 
@@ -211,9 +194,9 @@ def test_innerwf_4(change_dir, plugin):
     """
     wf = Workflow(name="wf4", workingdir="test_innerwf4_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NB", "out", "NB_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": 3})
-    nb = Node(name="NB", interface=interf_addtwo, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addtwo(), workingdir="nb", output_names=["out"])
     wf.add_nodes([na, nb])
     wf.connect("NA", "out", "NB", "a")
     nb.split(splitter="a").combine(combiner="a")
@@ -237,9 +220,9 @@ def test_innerwf_5(change_dir, plugin):
     """
     wf = Workflow(name="wf5", workingdir="test_innerwf5_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NB", "out", "NB_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": [3, 5]}, splitter="n")
-    nb = Node(name="NB", interface=interf_addtwo, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addtwo(), workingdir="nb", output_names=["out"])
     wf.add_nodes([na, nb])
     wf.connect("NA", "out", "NB", "a")
     nb.split(splitter=["a", "NA.n"]).combine(combiner="a")
@@ -264,9 +247,9 @@ def test_innerwf_5a(change_dir, plugin):
     """
     wf = Workflow(name="wf5a", workingdir="test_innerwf5a_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NB", "out", "NB_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": [3, 5]}, splitter="n")
-    nb = Node(name="NB", interface=interf_addtwo, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addtwo(), workingdir="nb", output_names=["out"])
     wf.add_nodes([na, nb])
     wf.connect("NA", "out", "NB", "a")
     nb.split(splitter=["a", "NA.n"]).combine(combiner=["a", "NA.n"])
@@ -292,9 +275,9 @@ def test_innerwf_5b(change_dir, plugin):
     """
     wf = Workflow(name="wf5b", workingdir="test_innerwf5b_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NB", "out", "NB_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": [3, 5]}, splitter="n")
-    nb = Node(name="NB", interface=interf_addtwo, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addtwo(), workingdir="nb", output_names=["out"])
     wf.add_nodes([na, nb])
     wf.connect("NA", "out", "NB", "a")
     nb.split(splitter=["a", "NA.n"]).combine(combiner=["NA.n"])
@@ -313,11 +296,11 @@ def test_innerwf_6(change_dir, plugin):
     """two nodes return lists, the third one have two inner inputs in scalar splitter"""
     wf = Workflow(name="wf6", workingdir="test_innerwf6_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NC", "out", "NC_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": 3})
-    nb = Node(name="NB", interface=interf_list_generator_10, workingdir="nb", output_names=["out"],
+    nb = Node(name="NB", interface=fun_list_generator_10(), workingdir="nb", output_names=["out"],
               inputs={"n": 3})
-    nc = Node(name="NC", interface=interf_addvar, workingdir="nc", output_names=["out"],
+    nc = Node(name="NC", interface=fun_addvar(), workingdir="nc", output_names=["out"],
               splitter=("b", "c"), combiner=["b", "c"])
     wf.add_nodes([na, nb, nc])
     wf.connect("NA", "out", "NC", "b")
@@ -343,11 +326,11 @@ def test_innerwf_6a(change_dir, plugin):
     """
     wf = Workflow(name="wf6a", workingdir="test_innerwf6a_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NC", "out", "NC_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": 3})
-    nb = Node(name="NB", interface=interf_list_generator_10, workingdir="nb", output_names=["out"],
+    nb = Node(name="NB", interface=fun_list_generator_10(), workingdir="nb", output_names=["out"],
               inputs={"n": 3})
-    nc = Node(name="NC", interface=interf_addvar, workingdir="nc", output_names=["out"],
+    nc = Node(name="NC", interface=fun_addvar(), workingdir="nc", output_names=["out"],
               splitter=["b", "c"], combiner=["b", "c"])
     wf.add_nodes([na, nb, nc])
     wf.connect("NA", "out", "NC", "b")
@@ -366,11 +349,11 @@ def test_innerwf_7(change_dir, plugin):
     """two nodes return lists, the third one have two inner inputs in scalar splitter"""
     wf = Workflow(name="wf7", workingdir="test_innerwf7_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NC", "out", "NC_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": [3, 5]}, splitter="n")
-    nb = Node(name="NB", interface=interf_list_generator_10, workingdir="nb", output_names=["out"],
+    nb = Node(name="NB", interface=fun_list_generator_10(), workingdir="nb", output_names=["out"],
               inputs={"n": [3, 5]}, splitter="n")
-    nc = Node(name="NC", interface=interf_addvar, workingdir="nc", output_names=["out"],
+    nc = Node(name="NC", interface=fun_addvar(), workingdir="nc", output_names=["out"],
               splitter=("b", "c"), combiner=["b", "c"])
     wf.add_nodes([na, nb, nc])
     wf.connect("NA", "out", "NC", "b")
@@ -398,9 +381,9 @@ def test_innerwf_8(change_dir, plugin):
     """
     wf = Workflow(name="wf8", workingdir="test_innerwf8_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NB", "out", "NB_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": 3})
-    nb = Node(name="NB", interface=interf_addtwo, workingdir="nb", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addtwo(), workingdir="nb", output_names=["out"])
     wf.add_nodes([na, nb])
     wf.connect("NA", "out", "NB", "a")
     nb.split(splitter="a")
@@ -424,10 +407,10 @@ def test_innerwf_9(change_dir, plugin):
     """
     wf = Workflow(name="wf8", workingdir="test_innerwf8_{}".format(plugin),
                   wf_output_names=[("NA", "out", "NA_out"), ("NB", "out", "NB_out")])
-    na = Node(name="NA", interface=interf_list_generator, workingdir="na", output_names=["out"],
+    na = Node(name="NA", interface=fun_list_generator(), workingdir="na", output_names=["out"],
               inputs={"n": 3})
-    nb = Node(name="NB", interface=interf_addtwo, workingdir="nb", output_names=["out"])
-    nc = Node(name="NC", interface=interf_addtwo, workingdir="nc", output_names=["out"])
+    nb = Node(name="NB", interface=fun_addtwo(), workingdir="nb", output_names=["out"])
+    nc = Node(name="NC", interface=fun_addtwo(), workingdir="nc", output_names=["out"])
     wf.add_nodes([na, nb, nc])
     wf.connect("NA", "out", "NB", "a")
     wf.connect("NB", "out", "NC", "a")

--- a/pydra/engine/tests/test_state.py
+++ b/pydra/engine/tests/test_state.py
@@ -3,13 +3,15 @@ import numpy as np
 
 from ..state import State
 from ..node import Node, Workflow
-from ..auxiliary import CurrentInterface
+from ..task import to_task
 
 from nipype import Function
 
 import pytest, pdb
 python35_only = pytest.mark.skipif(sys.version_info < (3, 5), reason="requires Python>3.4")
 
+
+@to_task
 def fun_addtwo(a):
     import time
     time.sleep(1)
@@ -17,26 +19,20 @@ def fun_addtwo(a):
         time.sleep(2)
     return a + 2
 
-_interf_addtwo = Function(function=fun_addtwo, input_names=["a"], output_names=["out"])
-interf_addtwo = CurrentInterface(interface=_interf_addtwo, name="addtwo")
 
-
+@to_task
 def fun_addvar(b, c):
     return b + c
 
-_interf_addvar = Function(function=fun_addvar, input_names=["b", "c"], output_names=["out"])
-interf_addvar = CurrentInterface(interface=_interf_addvar, name="addvar")
 
-
+@to_task
 def fun_addvar3(a, b, c):
     return a + b + c
 
-_interf_addvar3 = Function(function=fun_addvar3, input_names=["a", "b", "c"], output_names=["out"])
-interf_addvar3 = CurrentInterface(interface=_interf_addvar3, name="addvar3")
 
 
 def test_state_1():
-    nd = Node(name="NA", interface=interf_addtwo, splitter="a", combiner="a",
+    nd = Node(name="NA", interface=fun_addtwo(), splitter="a", combiner="a",
               inputs={"a": np.array([3, 5])})
     st = State(node=nd)
 
@@ -88,7 +84,7 @@ def test_state_1a():
 
 
 def test_state_2():
-    nd = Node(name="NA", interface=interf_addvar, splitter=("a", "b"), combiner="a",
+    nd = Node(name="NA", interface=fun_addvar(), splitter=("a", "b"), combiner="a",
               inputs={"a": np.array([3, 5]), "b": np.array([3, 5])})
     st = State(node=nd)
 
@@ -140,7 +136,7 @@ def test_state_2a():
 
 
 def test_state_3():
-    nd = Node(name="NA", interface=interf_addvar, splitter=["a", "b"], combiner="a",
+    nd = Node(name="NA", interface=fun_addvar(), splitter=["a", "b"], combiner="a",
               inputs={"a": np.array([3, 5]), "b": np.array([3, 5])})
     st = State(node=nd)
 
@@ -166,7 +162,7 @@ def test_state_3():
 
 
 def test_state_4():
-    nd = Node(name="NA", interface=_interf_addvar3, splitter=["a", ("b", "c")], combiner="b",
+    nd = Node(name="NA", interface=fun_addvar3(), splitter=["a", ("b", "c")], combiner="b",
               inputs={"a": np.array([3, 5]), "b": np.array([3, 5]), "c": np.array([3, 5])})
     st = State(node=nd)
 
@@ -192,7 +188,7 @@ def test_state_4():
 
 
 def test_state_5():
-    nd = Node(name="NA", interface=_interf_addvar3, splitter=("a", ["b", "c"]), combiner="b",
+    nd = Node(name="NA", interface=fun_addvar3(), splitter=("a", ["b", "c"]), combiner="b",
               inputs={"a": np.array([[3, 5], [3, 5]]), "b": np.array([3, 5]),
                       "c": np.array([3, 5])})
     st = State(node=nd)


### PR DESCRIPTION
moving from `CurrentInterface` to `FunctionTask` in `Node`

all test from `test_node`, `tes_node_combine` and `test_node_inner` (the subset that it was merged in this branch) should work for `plugin="serial"`.

In `task.py` I only included the changes you introduced on Friday.