### PR TITLE
allowing for limitted dask testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ env:
 # Useful for testing un-released upstream fixes
 matrix:
   include:
+  - python: 3.7
+    env:
+      - INSTALL_TYPE="develop"
+      - CHECK_TYPE="test_dask"
   - os: osx
     osx_image: xcode11.2
     language: generic

--- a/ci/none.sh
+++ b/ci/none.sh
@@ -40,6 +40,10 @@ function travis_before_script {
             # extras don't seem possible with setup.py install, so switch to pip
             pip install ".[test]"
         fi
+    elif [ "$CHECK_TYPE" = "test_dask" ]; then
+        if [ "$INSTALL_TYPE" = "develop" ]; then
+            pip install -e ".[dask]"
+        fi
     elif [ "$CHECK_TYPE" = "style" ]; then
         pip install black==19.3b0
     fi
@@ -48,6 +52,8 @@ function travis_before_script {
 function travis_script {
     if [ "$CHECK_TYPE" = "test" ]; then
         pytest -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules pydra
+    elif [ "$CHECK_TYPE" = "test_dask" ]; then
+        pytest -vs -n auto --cov pydra --cov-config .coveragerc --cov-report xml:cov.xml --doctest-modules --dask pydra/engine
     elif [ "$CHECK_TYPE" = "style" ]; then
         black --check pydra tools setup.py
     fi

--- a/pydra/conftest.py
+++ b/pydra/conftest.py
@@ -1,0 +1,25 @@
+import shutil
+
+
+def pytest_addoption(parser):
+    parser.addoption("--dask", action="store_true", help="run all combinations")
+
+
+def pytest_generate_tests(metafunc):
+    if "plugin_dask_opt" in metafunc.fixturenames:
+        if bool(shutil.which("sbatch")):
+            Plugins = ["cf", "slurm"]
+        else:
+            Plugins = ["cf"]
+        if metafunc.config.getoption("dask"):
+            Plugins.append("dask")
+        metafunc.parametrize("plugin_dask_opt", Plugins)
+
+    if "plugin" in metafunc.fixturenames:
+        if metafunc.config.getoption("dask"):
+            Plugins = []
+        elif bool(shutil.which("sbatch")):
+            Plugins = ["cf", "slurm"]
+        else:
+            Plugins = ["cf"]
+        metafunc.parametrize("plugin", Plugins)

--- a/pydra/engine/boutiques.py
+++ b/pydra/engine/boutiques.py
@@ -1,0 +1,215 @@
+import typing as ty
+import json
+import attr
+from urllib.request import urlretrieve
+from pathlib import Path
+from functools import reduce
+
+from ..utils.messenger import AuditFlag
+from ..engine import ShellCommandTask
+from ..engine.specs import SpecInfo, ShellSpec, ShellOutSpec, File, attr_fields
+from .helpers_file import is_local_file
+
+
+class BoshTask(ShellCommandTask):
+    """Shell Command Task based on the Boutiques descriptor"""
+
+    def __init__(
+        self,
+        zenodo_id=None,
+        bosh_file=None,
+        audit_flags: AuditFlag = AuditFlag.NONE,
+        cache_dir=None,
+        input_spec_names: ty.Optional[ty.List] = None,
+        messenger_args=None,
+        messengers=None,
+        name=None,
+        output_spec_names: ty.Optional[ty.List] = None,
+        rerun=False,
+        strip=False,
+        **kwargs,
+    ):
+        """
+        Initialize this task.
+
+        Parameters
+        ----------
+        zenodo_id: :obj: str
+            Zenodo ID
+        bosh_file : : str
+            json file with the boutiques descriptors
+        audit_flags : :obj:`pydra.utils.messenger.AuditFlag`
+            Auditing configuration
+        cache_dir : :obj:`os.pathlike`
+            Cache directory
+        input_spec_names : :obj: list
+            Input names for input_spec.
+        messenger_args :
+            TODO
+        messengers :
+            TODO
+        name : :obj:`str`
+            Name of this task.
+        output_spec_names : :obj: list
+            Output names for output_spec.
+        strip : :obj:`bool`
+            TODO
+
+        """
+        self.cache_dir = cache_dir
+        if (bosh_file and zenodo_id) or not (bosh_file or zenodo_id):
+            raise Exception("either bosh or zenodo_id has to be specified")
+        elif zenodo_id:
+            self.bosh_file = self._download_spec(zenodo_id)
+        else:  # bosh_file
+            self.bosh_file = bosh_file
+
+        with self.bosh_file.open() as f:
+            self.bosh_spec = json.load(f)
+
+        self.input_spec = self._prepare_input_spec(names_subset=input_spec_names)
+        self.output_spec = self._prepare_output_spec(names_subset=output_spec_names)
+        self.bindings = ["-v", f"{self.bosh_file.parent}:{self.bosh_file.parent}:ro"]
+
+        super(BoshTask, self).__init__(
+            name=name,
+            input_spec=self.input_spec,
+            output_spec=self.output_spec,
+            executable=["bosh", "exec", "launch"],
+            args=["-s"],
+            audit_flags=audit_flags,
+            messengers=messengers,
+            messenger_args=messenger_args,
+            cache_dir=self.cache_dir,
+            strip=strip,
+            rerun=rerun,
+            **kwargs,
+        )
+        self.strip = strip
+
+    def _download_spec(self, zenodo_id):
+        """
+        usind boutiques Searcher to find url of zenodo file for a specific id,
+        and download the file to self.cache_dir
+        """
+        from boutiques.searcher import Searcher
+
+        searcher = Searcher(zenodo_id, exact_match=True)
+        hits = searcher.zenodo_search().json()["hits"]["hits"]
+        if len(hits) == 0:
+            raise Exception(f"can't find zenodo spec for {zenodo_id}")
+        elif len(hits) > 1:
+            raise Exception(f"too many hits for {zenodo_id}")
+        else:
+            zenodo_url = hits[0]["files"][0]["links"]["self"]
+            zenodo_file = self.cache_dir / f"zenodo.{zenodo_id}.json"
+            urlretrieve(zenodo_url, zenodo_file)
+            return zenodo_file
+
+    def _prepare_input_spec(self, names_subset=None):
+        """ creating input spec from the zenodo file
+            if name_subset provided, only names from the subset will be used in the spec
+        """
+        binputs = self.bosh_spec["inputs"]
+        self._input_spec_keys = {}
+        fields = []
+        for input in binputs:
+            name = input["id"]
+            if names_subset is None:
+                pass
+            elif name not in names_subset:
+                continue
+            else:
+                names_subset.remove(name)
+            if input["type"] == "File":
+                tp = File
+            elif input["type"] == "String":
+                tp = str
+            elif input["type"] == "Number":
+                tp = float
+            elif input["type"] == "Flag":
+                tp = bool
+            else:
+                tp = None
+            # adding list
+            if tp and "list" in input and input["list"]:
+                tp = ty.List[tp]
+
+            mdata = {
+                "help_string": input.get("description", None) or input["name"],
+                "mandatory": not input["optional"],
+                "argstr": input.get("command-line-flag", None),
+            }
+            fields.append((name, tp, mdata))
+            self._input_spec_keys[input["value-key"]] = "{" + f"{name}" + "}"
+        if names_subset:
+            raise RuntimeError(f"{names_subset} are not in the zenodo input spec")
+        spec = SpecInfo(name="Inputs", fields=fields, bases=(ShellSpec,))
+        return spec
+
+    def _prepare_output_spec(self, names_subset=None):
+        """ creating output spec from the zenodo file
+            if name_subset provided, only names from the subset will be used in the spec
+        """
+        boutputs = self.bosh_spec["output-files"]
+        fields = []
+        for output in boutputs:
+            name = output["id"]
+            if names_subset is None:
+                pass
+            elif name not in names_subset:
+                continue
+            else:
+                names_subset.remove(name)
+            path_template = reduce(
+                lambda s, r: s.replace(*r),
+                self._input_spec_keys.items(),
+                output["path-template"],
+            )
+            mdata = {
+                "help_string": output.get("description", None) or output["name"],
+                "mandatory": not output["optional"],
+                "output_file_template": path_template,
+            }
+            fields.append((name, attr.ib(type=File, metadata=mdata)))
+
+        if names_subset:
+            raise RuntimeError(f"{names_subset} are not in the zenodo output spec")
+        spec = SpecInfo(name="Outputs", fields=fields, bases=(ShellOutSpec,))
+        return spec
+
+    def _command_args_single(self, state_ind, ind=None):
+        """Get command line arguments for a single state"""
+        input_filepath = self._bosh_invocation_file(state_ind=state_ind, ind=ind)
+        cmd_list = (
+            self.inputs.executable
+            + [str(self.bosh_file), input_filepath]
+            + self.inputs.args
+            + self.bindings
+        )
+        return cmd_list
+
+    def _bosh_invocation_file(self, state_ind, ind=None):
+        """creating bosh invocation file - json file with inputs values"""
+        input_json = {}
+        for f in attr_fields(self.inputs):
+            if f.name in ["executable", "args"]:
+                continue
+            if self.state and f"{self.name}.{f.name}" in state_ind:
+                value = getattr(self.inputs, f.name)[state_ind[f"{self.name}.{f.name}"]]
+            else:
+                value = getattr(self.inputs, f.name)
+            # adding to the json file if specified by the user
+            if value is not attr.NOTHING and value != "NOTHING":
+                if is_local_file(f):
+                    value = Path(value)
+                    self.bindings.extend(["-v", f"{value.parent}:{value.parent}:ro"])
+                    value = str(value)
+
+                input_json[f.name] = value
+
+        filename = self.cache_dir / f"{self.name}-{ind}.json"
+        with open(filename, "w") as jsonfile:
+            json.dump(input_json, jsonfile)
+
+        return str(filename)

--- a/pydra/engine/core.py
+++ b/pydra/engine/core.py
@@ -532,29 +532,37 @@ class TaskBase:
                 return True
         return False
 
-    def _combined_output(self):
+    def _combined_output(self, return_inputs=False):
         combined_results = []
         for (gr, ind_l) in self.state.final_combined_ind_mapping.items():
-            combined_results.append([])
+            combined_results_gr = []
             for ind in ind_l:
                 result = load_result(self.checksum_states(ind), self.cache_locations)
                 if result is None:
                     return None
-                combined_results[gr].append(result)
+                if return_inputs is True or return_inputs == "val":
+                    result = (self.state.states_val[ind], result)
+                elif return_inputs == "ind":
+                    result = (self.state.states_ind[ind], result)
+                combined_results_gr.append(result)
+            combined_results.append(combined_results_gr)
         if len(combined_results) == 1 and self.state.splitter_rpn_final == []:
             # in case it's full combiner, removing the nested structure
             return combined_results[0]
         else:
             return combined_results
 
-    def result(self, state_index=None):
+    def result(self, state_index=None, return_inputs=False):
         """
         Retrieve the outcomes of this particular task.
 
         Parameters
         ----------
-        state_index :
-            TODO
+        state_index : :obj: `int`
+            index of the element for task with splitter and multiple states
+        return_inputs : :obj: `bool`, :obj:`str`
+            if True or "val" result is returned together with values of the input fields,
+            if "ind" result is returned together with indices of the input fields
 
         Returns
         -------
@@ -567,7 +575,7 @@ class TaskBase:
             if state_index is None:
                 # if state_index=None, collecting all results
                 if self.state.combiner:
-                    return self._combined_output()
+                    return self._combined_output(return_inputs=return_inputs)
                 else:
                     results = []
                     for checksum in self.checksum_states():
@@ -575,20 +583,42 @@ class TaskBase:
                         if result is None:
                             return None
                         results.append(result)
-                    return results
+                    if return_inputs is True or return_inputs == "val":
+                        return list(zip(self.state.states_val, results))
+                    elif return_inputs == "ind":
+                        return list(zip(self.state.states_ind, results))
+                    else:
+                        return results
             else:  # state_index is not None
                 if self.state.combiner:
-                    return self._combined_output()[state_index]
+                    return self._combined_output(return_inputs=return_inputs)[
+                        state_index
+                    ]
                 result = load_result(
                     self.checksum_states(state_index), self.cache_locations
                 )
-                return result
+                if return_inputs is True or return_inputs == "val":
+                    return (self.state.states_val[state_index], result)
+                elif return_inputs == "ind":
+                    return (self.state.states_ind[state_index], result)
+                else:
+                    return result
         else:
             if state_index is not None:
                 raise ValueError("Task does not have a state")
             checksum = self.checksum
             result = load_result(checksum, self.cache_locations)
-            return result
+            if return_inputs is True or return_inputs == "val":
+                inputs_val = {
+                    f"{self.name}.{inp}": getattr(self.inputs, inp)
+                    for inp in self.input_names
+                }
+                return (inputs_val, result)
+            elif return_inputs == "ind":
+                inputs_ind = {f"{self.name}.{inp}": None for inp in self.input_names}
+                return (inputs_ind, result)
+            else:
+                return result
 
     def _reset(self):
         """Reset the connections between inputs and LazyFields."""

--- a/pydra/engine/helpers_file.py
+++ b/pydra/engine/helpers_file.py
@@ -87,27 +87,66 @@ def hash_file(afile, chunk_len=8192, crypto=sha256, raise_notfound=True):
     return crypto_obj.hexdigest()
 
 
-def hash_dir(dirpath, raise_notfound=True):
+def hash_dir(
+    dirpath,
+    crypto=sha256,
+    ignore_hidden_files=False,
+    ignore_hidden_dirs=False,
+    raise_notfound=True,
+):
+    """Compute hash of directory contents.
+
+    This function computes the hash of every file in directory `dirpath` and then
+    computes the hash of that list of hashes to return a single hash value. The
+    directory is traversed recursively.
+
+    Parameters
+    ----------
+    dirpath : :obj:`str`
+        Path to directory.
+    crypto : :obj: `function`
+        cryptographic hash functions
+    ignore_hidden_files : :obj:`bool`
+        If `True`, ignore filenames that begin with `.`.
+    ignore_hidden_dirs : :obj:`bool`
+        If `True`, ignore files in directories that begin with `.`.
+    raise_notfound : :obj:`bool`
+        If `True` and `dirpath` does not exist, raise `FileNotFound` exception. If
+        `False` and `dirpath` does not exist, return `None`.
+
+    Returns
+    -------
+    hash : :obj:`str`
+        Hash of the directory contents.
+    """
     from .specs import LazyField
 
     if dirpath is None or isinstance(dirpath, LazyField) or isinstance(dirpath, list):
         return None
     if not Path(dirpath).is_dir():
         if raise_notfound:
-            raise RuntimeError(f"Directory {dirpath} not found.")
+            raise FileNotFoundError(f"Directory {dirpath} not found.")
         return None
 
-    def search_dir(path):
-        path = Path(path)
-        file_list = []
-        for el in path.iterdir():
-            if el.is_file():
-                file_list.append(hash_file(el))
-            else:
-                file_list.append(search_dir(path / el))
-        return file_list
+    file_hashes = []
+    for dpath, dirnames, filenames in os.walk(dirpath):
+        # Sort in-place to guarantee order.
+        dirnames.sort()
+        filenames.sort()
+        dpath = Path(dpath)
+        if ignore_hidden_dirs and dpath.name.startswith(".") and str(dpath) != dirpath:
+            continue
+        for filename in filenames:
+            if ignore_hidden_files and filename.startswith("."):
+                continue
+            this_hash = hash_file(dpath / filename)
+            file_hashes.append(this_hash)
 
-    return search_dir(dirpath)
+    crypto_obj = crypto()
+    for h in file_hashes:
+        crypto_obj.update(h.encode())
+
+    return crypto_obj.hexdigest()
 
 
 def _parse_mount_table(exit_code, output):

--- a/pydra/engine/specs.py
+++ b/pydra/engine/specs.py
@@ -311,9 +311,8 @@ class ShellOutSpec(BaseSpec):
                 if fld.type is File:
                     # assuming that field should have either default or metadata, but not both
                     if (
-                        not (fld.default is None or fld.default == attr.NOTHING)
-                        and fld.metadata
-                    ):
+                        fld.default is None or fld.default == attr.NOTHING
+                    ) and not fld.metadata:  # TODO: is it right?
                         raise Exception("File has to have default value or metadata")
                     elif not fld.default == attr.NOTHING:
                         additional_out[fld.name] = self._field_defaultvalue(
@@ -360,9 +359,23 @@ class ShellOutSpec(BaseSpec):
         if "value" in fld.metadata:
             return output_dir / fld.metadata["value"]
         elif "output_file_template" in fld.metadata:
-            return output_dir / fld.metadata["output_file_template"].format(
-                **inputs.__dict__
+            sfx_tmpl = (output_dir / fld.metadata["output_file_template"]).suffixes
+            if sfx_tmpl:
+                # removing suffix from input field if template has it's own suffix
+                inputs_templ = {
+                    k: v.split(".")[0]
+                    for k, v in inputs.__dict__.items()
+                    if isinstance(v, str)
+                }
+            else:
+                inputs_templ = {
+                    k: v for k, v in inputs.__dict__.items() if isinstance(v, str)
+                }
+            out_path = output_dir / fld.metadata["output_file_template"].format(
+                **inputs_templ
             )
+            return out_path
+
         elif "callable" in fld.metadata:
             return fld.metadata["callable"](fld.name, output_dir)
         else:

--- a/pydra/engine/task.py
+++ b/pydra/engine/task.py
@@ -399,13 +399,16 @@ class ShellCommandTask(TaskBase):
         else:
             args = self.command_args
         if args:
-            # removing emty strings
+            # removing empty strings
             args = [str(el) for el in args if el not in ["", " "]]
             keys = ["return_code", "stdout", "stderr"]
             values = execute(args, strip=self.strip)
             self.output_ = dict(zip(keys, values))
             if self.output_["return_code"]:
-                raise RuntimeError(self.output_["stderr"])
+                if self.output_["stderr"]:
+                    raise RuntimeError(self.output_["stderr"])
+                else:
+                    raise RuntimeError(self.output_["stdout"])
 
 
 class ContainerTask(ShellCommandTask):

--- a/pydra/engine/tests/test_boutiques.py
+++ b/pydra/engine/tests/test_boutiques.py
@@ -1,0 +1,174 @@
+import os, shutil
+import subprocess as sp
+from pathlib import Path
+import pytest
+
+from ..core import Workflow
+from ..task import ShellCommandTask
+from ..submitter import Submitter
+from ..boutiques import BoshTask
+from .utils import result_no_submitter, result_submitter, no_win
+
+need_bosh_docker = pytest.mark.skipif(
+    shutil.which("docker") is None
+    or sp.call(["docker", "info"] or sp.call(["bosh", "version"])),
+    reason="requires docker and bosh",
+)
+
+if bool(shutil.which("sbatch")):
+    Plugins = ["cf", "slurm"]
+else:
+    Plugins = ["cf"]
+
+Infile = Path(__file__).resolve().parent / "data_tests" / "test.nii.gz"
+
+
+@no_win
+@need_bosh_docker
+@pytest.mark.flaky(reruns=2)
+@pytest.mark.parametrize(
+    "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
+)
+@pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
+@pytest.mark.parametrize("plugin", Plugins)
+def test_boutiques_1(maskfile, plugin, results_function):
+    """ simple task to run fsl.bet using BoshTask"""
+    btask = BoshTask(name="NA", zenodo_id="1482743")
+    btask.inputs.infile = Infile
+    btask.inputs.maskfile = maskfile
+    res = results_function(btask, plugin)
+
+    assert res.output.return_code == 0
+
+    # checking if the outfile exists and if it has proper name
+    assert res.output.outfile.name == "test_brain.nii.gz"
+    assert res.output.outfile.exists()
+    # other files should also have proper names, but they do not exist
+    assert res.output.out_outskin_off.name == "test_brain_outskin_mesh.off"
+    assert not res.output.out_outskin_off.exists()
+
+
+@no_win
+@need_bosh_docker
+def test_boutiques_spec_1():
+    """ testing spec: providing input/output fields names"""
+    btask = BoshTask(
+        name="NA",
+        zenodo_id="1482743",
+        infile=Infile,
+        maskfile="test_brain.nii.gz",
+        input_spec_names=["infile", "maskfile"],
+        output_spec_names=["outfile", "out_outskin_off"],
+    )
+
+    assert len(btask.input_spec.fields) == 2
+    assert btask.input_spec.fields[0][0] == "infile"
+    assert btask.input_spec.fields[1][0] == "maskfile"
+    assert hasattr(btask.inputs, "infile")
+    assert hasattr(btask.inputs, "maskfile")
+
+    assert len(btask.output_spec.fields) == 2
+    assert btask.output_spec.fields[0][0] == "outfile"
+    assert btask.output_spec.fields[1][0] == "out_outskin_off"
+
+
+@no_win
+@need_bosh_docker
+def test_boutiques_spec_2():
+    """ testing spec: providing partial input/output fields names"""
+    btask = BoshTask(
+        name="NA",
+        zenodo_id="1482743",
+        infile=Infile,
+        maskfile="test_brain.nii.gz",
+        input_spec_names=["infile"],
+        output_spec_names=[],
+    )
+
+    assert len(btask.input_spec.fields) == 1
+    assert btask.input_spec.fields[0][0] == "infile"
+    assert hasattr(btask.inputs, "infile")
+    # input doesn't see maskfile
+    assert not hasattr(btask.inputs, "maskfile")
+
+    assert len(btask.output_spec.fields) == 0
+
+
+@no_win
+@need_bosh_docker
+@pytest.mark.parametrize(
+    "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
+)
+@pytest.mark.parametrize("plugin", Plugins)
+def test_boutiques_wf_1(maskfile, plugin):
+    """ wf with one task that runs fsl.bet using BoshTask"""
+    wf = Workflow(name="wf", input_spec=["maskfile", "infile"])
+    wf.inputs.maskfile = maskfile
+    wf.inputs.infile = Infile
+
+    wf.add(
+        BoshTask(
+            name="bet",
+            zenodo_id="1482743",
+            infile=wf.lzin.infile,
+            maskfile=wf.lzin.maskfile,
+        )
+    )
+
+    wf.set_output([("outfile", wf.bet.lzout.outfile)])
+
+    with Submitter(plugin=plugin) as sub:
+        wf(submitter=sub)
+
+    res = wf.result()
+    assert res.output.outfile.name == "test_brain.nii.gz"
+    assert res.output.outfile.exists()
+
+
+@no_win
+@need_bosh_docker
+@pytest.mark.parametrize(
+    "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
+)
+@pytest.mark.parametrize("plugin", Plugins)
+def test_boutiques_wf_2(maskfile, plugin):
+    """ wf with two BoshTasks (fsl.bet and fsl.stats) and one ShellTask"""
+    wf = Workflow(name="wf", input_spec=["maskfile", "infile"])
+    wf.inputs.maskfile = maskfile
+    wf.inputs.infile = Infile
+
+    wf.add(
+        BoshTask(
+            name="bet",
+            zenodo_id="1482743",
+            infile=wf.lzin.infile,
+            maskfile=wf.lzin.maskfile,
+        )
+    )
+    wf.add(
+        BoshTask(
+            name="stat", zenodo_id="3240521", input_file=wf.bet.lzout.outfile, v=True
+        )
+    )
+    wf.add(ShellCommandTask(name="cat", executable="cat", args=wf.stat.lzout.output))
+
+    wf.set_output(
+        [
+            ("outfile_bet", wf.bet.lzout.outfile),
+            ("out_stat", wf.stat.lzout.output),
+            ("out", wf.cat.lzout.stdout),
+        ]
+    )
+
+    with Submitter(plugin=plugin) as sub:
+        wf(submitter=sub)
+
+    res = wf.result()
+    assert res.output.outfile_bet.name == "test_brain.nii.gz"
+    assert res.output.outfile_bet.exists()
+
+    assert res.output.out_stat.name == "output.txt"
+    assert res.output.out_stat.exists()
+
+    assert int(res.output.out.rstrip().split()[0]) == 11534336
+    assert float(res.output.out.rstrip().split()[1]) == 11534336.0

--- a/pydra/engine/tests/test_boutiques.py
+++ b/pydra/engine/tests/test_boutiques.py
@@ -21,6 +21,7 @@ Infile = Path(__file__).resolve().parent / "data_tests" / "test.nii.gz"
 
 @no_win
 @need_bosh_docker
+@pytest.mark.flaky(reruns=2)  # need for travis
 @pytest.mark.parametrize(
     "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
 )

--- a/pydra/engine/tests/test_boutiques.py
+++ b/pydra/engine/tests/test_boutiques.py
@@ -11,26 +11,20 @@ from .utils import result_no_submitter, result_submitter, no_win
 
 need_bosh_docker = pytest.mark.skipif(
     shutil.which("docker") is None
-    or sp.call(["docker", "info"] or sp.call(["bosh", "version"])),
+    or sp.call(["docker", "info"])
+    or sp.call(["which", "bosh"]),
     reason="requires docker and bosh",
 )
-
-if bool(shutil.which("sbatch")):
-    Plugins = ["cf", "slurm"]
-else:
-    Plugins = ["cf"]
 
 Infile = Path(__file__).resolve().parent / "data_tests" / "test.nii.gz"
 
 
 @no_win
 @need_bosh_docker
-@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize(
     "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
 )
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_boutiques_1(maskfile, plugin, results_function):
     """ simple task to run fsl.bet using BoshTask"""
     btask = BoshTask(name="NA", zenodo_id="1482743")
@@ -99,7 +93,6 @@ def test_boutiques_spec_2():
 @pytest.mark.parametrize(
     "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
 )
-@pytest.mark.parametrize("plugin", Plugins)
 def test_boutiques_wf_1(maskfile, plugin):
     """ wf with one task that runs fsl.bet using BoshTask"""
     wf = Workflow(name="wf", input_spec=["maskfile", "infile"])
@@ -130,7 +123,6 @@ def test_boutiques_wf_1(maskfile, plugin):
 @pytest.mark.parametrize(
     "maskfile", ["test_brain.nii.gz", "test_brain", "test_brain.nii"]
 )
-@pytest.mark.parametrize("plugin", Plugins)
 def test_boutiques_wf_2(maskfile, plugin):
     """ wf with two BoshTasks (fsl.bet and fsl.stats) and one ShellTask"""
     wf = Workflow(name="wf", input_spec=["maskfile", "infile"])

--- a/pydra/engine/tests/test_dockertask.py
+++ b/pydra/engine/tests/test_dockertask.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import os, sys, shutil
-import subprocess as sp
+import os
 import pytest
 import attr
 
@@ -9,15 +8,7 @@ from ..task import DockerTask, ShellCommandTask
 from ..submitter import Submitter
 from ..core import Workflow
 from ..specs import ShellOutSpec, SpecInfo, File, DockerSpec
-
-need_docker = pytest.mark.skipif(
-    shutil.which("docker") is None or sp.call(["docker", "info"]),
-    reason="no docker within the container",
-)
-no_win = pytest.mark.skipif(
-    sys.platform.startswith("win"),
-    reason="docker command not adjusted for windows docker",
-)
+from .utils import no_win, need_docker
 
 
 @no_win

--- a/pydra/engine/tests/test_dockertask.py
+++ b/pydra/engine/tests/test_dockertask.py
@@ -10,11 +10,6 @@ from ..submitter import Submitter
 from ..core import Workflow
 from ..specs import ShellOutSpec, SpecInfo, File, DockerSpec
 
-if bool(shutil.which("sbatch")):
-    Plugins = ["cf", "slurm"]
-else:
-    Plugins = ["cf"]
-
 need_docker = pytest.mark.skipif(
     shutil.which("docker") is None or sp.call(["docker", "info"]),
     reason="no docker within the container",
@@ -49,7 +44,6 @@ def test_docker_1_nosubm():
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_1(plugin):
     """ simple command in a container, a default bindings and working directory is added
         using submitter
@@ -69,7 +63,6 @@ def test_docker_1(plugin):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_1_dockerflag(plugin):
     """ simple command in a container, a default bindings and working directory is added
         using ShellComandTask with container_info=("docker", image)
@@ -91,7 +84,6 @@ def test_docker_1_dockerflag(plugin):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_1_dockerflag_exception(plugin):
     """using ShellComandTask with container_info=("docker"), no image provided"""
     cmd = "whoami"
@@ -124,7 +116,6 @@ def test_docker_2_nosubm():
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_2(plugin):
     """ a command with arguments, cmd and args given as executable
         using submitter
@@ -147,7 +138,6 @@ def test_docker_2(plugin):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_2_dockerflag(plugin):
     """ a command with arguments, cmd and args given as executable
         using ShellComandTask with container_info=("docker", image)
@@ -197,7 +187,6 @@ def test_docker_2a_nosubm():
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_2a(plugin):
     """ a command with arguments, using executable and args
         using submitter
@@ -225,7 +214,6 @@ def test_docker_2a(plugin):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_3(plugin, tmpdir):
     """ a simple command in container with bindings,
         creating directory in tmp dir and checking if it is in the container
@@ -249,7 +237,6 @@ def test_docker_3(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_3_dockerflag(plugin, tmpdir):
     """ a simple command in container with bindings,
         creating directory in tmp dir and checking if it is in the container
@@ -276,7 +263,6 @@ def test_docker_3_dockerflag(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_3_dockerflagbind(plugin, tmpdir):
     """ a simple command in container with bindings,
         creating directory in tmp dir and checking if it is in the container
@@ -303,7 +289,6 @@ def test_docker_3_dockerflagbind(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_4(plugin, tmpdir):
     """ task reads the file that is bounded to the container
         specifying bindings,
@@ -330,7 +315,6 @@ def test_docker_4(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_4_dockerflag(plugin, tmpdir):
     """ task reads the file that is bounded to the container
         specifying bindings,
@@ -360,7 +344,6 @@ def test_docker_4_dockerflag(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_st_1(plugin):
     """ commands without arguments in container
         splitter = executable
@@ -385,7 +368,6 @@ def test_docker_st_1(plugin):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_st_2(plugin):
     """ command with arguments in docker, checking the distribution
         splitter = image
@@ -410,7 +392,6 @@ def test_docker_st_2(plugin):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_st_3(plugin):
     """ outer splitter image and executable
     """
@@ -429,7 +410,6 @@ def test_docker_st_3(plugin):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_st_4(plugin):
     """ outer splitter image and executable, combining with images
     """
@@ -472,7 +452,6 @@ def test_docker_st_4(plugin):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_docker_1(plugin, tmpdir):
     """ a workflow with two connected task
         the first one read the file that is bounded to the container,
@@ -517,7 +496,6 @@ def test_wf_docker_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_docker_1_dockerflag(plugin, tmpdir):
     """ a workflow with two connected task
         the first one read the file that is bounded to the container,
@@ -558,7 +536,6 @@ def test_wf_docker_1_dockerflag(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_docker_2pre(plugin, tmpdir):
     """ a workflow with two connected task that run python scripts
         the first one creates a text file and the second one reads the file
@@ -580,7 +557,6 @@ def test_wf_docker_2pre(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_docker_2(plugin, tmpdir):
     """ a workflow with two connected task that run python scripts
         the first one creates a text file and the second one reads the file
@@ -621,7 +597,6 @@ def test_wf_docker_2(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_docker_3(plugin, tmpdir):
     """ a workflow with two connected task
         the first one read the file that contains the name of the image,
@@ -665,7 +640,6 @@ def test_wf_docker_3(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_outputspec_1(plugin, tmpdir):
     """
         customised output_spec, adding files to the output, providing specific pathname
@@ -694,7 +668,6 @@ def test_docker_outputspec_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_1(plugin, tmpdir):
     """ a simple customized input spec for docker task """
     filename = str(tmpdir.join("file_pydra.txt"))
@@ -736,7 +709,6 @@ def test_docker_inputspec_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_1a(plugin, tmpdir):
     """ a simple customized input spec for docker task
         a default value is used
@@ -776,7 +748,6 @@ def test_docker_inputspec_1a(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_2(plugin, tmpdir):
     """ a customized input spec with two fields for docker task """
     filename_1 = tmpdir.join("file_pydra.txt")
@@ -825,7 +796,6 @@ def test_docker_inputspec_2(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_2a_except(plugin, tmpdir):
     """ a customized input spec with two fields
         first one uses a default, and second doesn't - raises a dataclass exception
@@ -877,7 +847,6 @@ def test_docker_inputspec_2a_except(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_2a(plugin, tmpdir):
     """ a customized input spec with two fields
         first one uses a default value
@@ -929,7 +898,6 @@ def test_docker_inputspec_2a(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_3(plugin, tmpdir):
     """ input file is in the container, so metadata["container_path"]: True,
         the input will be treated as a str """
@@ -973,7 +941,6 @@ def test_docker_inputspec_3(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_3a(plugin, tmpdir):
     """ input file does not exist in the local file system,
         but metadata["container_path"] is not used,
@@ -1017,7 +984,6 @@ def test_docker_inputspec_3a(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_cmd_inputspec_copyfile_1(plugin, tmpdir):
     """ shelltask changes a file in place,
         adding copyfile=True to the file-input from input_spec
@@ -1080,7 +1046,6 @@ def test_docker_cmd_inputspec_copyfile_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_state_1(plugin, tmpdir):
     """ a customised input spec for a docker file with a splitter,
         splitter is on files
@@ -1129,7 +1094,6 @@ def test_docker_inputspec_state_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_inputspec_state_1b(plugin, tmpdir):
     """ a customised input spec for a docker file with a splitter,
         files from the input spec have the same path in the local os and the container,
@@ -1179,7 +1143,6 @@ def test_docker_inputspec_state_1b(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_wf_inputspec_1(plugin, tmpdir):
     """ a customized input spec for workflow with docker tasks """
     filename = tmpdir.join("file_pydra.txt")
@@ -1231,7 +1194,6 @@ def test_docker_wf_inputspec_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_wf_state_inputspec_1(plugin, tmpdir):
     """ a customized input spec for workflow with docker tasks that has a state"""
     file_1 = tmpdir.join("file_pydra.txt")
@@ -1289,7 +1251,6 @@ def test_docker_wf_state_inputspec_1(plugin, tmpdir):
 
 @no_win
 @need_docker
-@pytest.mark.parametrize("plugin", Plugins)
 def test_docker_wf_ndst_inputspec_1(plugin, tmpdir):
     """ a customized input spec for workflow with docker tasks with states"""
     file_1 = tmpdir.join("file_pydra.txt")

--- a/pydra/engine/tests/test_helpers.py
+++ b/pydra/engine/tests/test_helpers.py
@@ -1,5 +1,7 @@
 import os
+import hashlib
 from pathlib import Path
+import random
 import platform
 
 import pytest
@@ -143,26 +145,54 @@ def test_hash_value_dir(tmpdir):
     with open(file_2, "w") as f:
         f.write("hi")
 
-    assert hash_value(tmpdir, tp=Directory) == hash_value([file_1, file_2], tp=File)
-    assert hash_value(tmpdir, tp=Directory) == helpers_file.hash_dir(tmpdir)
+    test_sha = hashlib.sha256()
+    for fx in [file_1, file_2]:
+        test_sha.update(helpers_file.hash_file(fx).encode())
+
+    bad_sha = hashlib.sha256()
+    for fx in [file_2, file_1]:
+        bad_sha.update(helpers_file.hash_file(fx).encode())
+
+    orig_hash = helpers_file.hash_dir(tmpdir)
+
+    assert orig_hash == test_sha.hexdigest()
+    assert orig_hash != bad_sha.hexdigest()
+    assert orig_hash == hash_value(tmpdir, tp=Directory)
 
 
 def test_hash_value_nested(tmpdir):
+    hidden = tmpdir.mkdir(".hidden")
     nested = tmpdir.mkdir("nested")
     file_1 = tmpdir.join("file_1.txt")
-    file_2 = nested.join("file_2.txt")
-    file_3 = nested.join("file_3.txt")
-    with open(file_1, "w") as f:
-        f.write("hello")
-    with open(file_2, "w") as f:
-        f.write("hi")
-    with open(file_3, "w") as f:
-        f.write("hola")
+    file_2 = hidden.join("file_2.txt")
+    file_3 = nested.join(".file_3.txt")
+    file_4 = nested.join("file_4.txt")
 
-    assert hash_value(tmpdir, tp=Directory) == hash_value(
-        [file_1, [file_2, file_3]], tp=File
+    test_sha = hashlib.sha256()
+    for fx in [file_1, file_2, file_3, file_4]:
+        with open(fx, "w") as f:
+            f.write(str(random.randint(0, 1000)))
+        test_sha.update(helpers_file.hash_file(fx).encode())
+
+    orig_hash = helpers_file.hash_dir(tmpdir)
+
+    assert orig_hash == test_sha.hexdigest()
+    assert orig_hash == hash_value(tmpdir, tp=Directory)
+
+    nohidden_hash = helpers_file.hash_dir(
+        tmpdir, ignore_hidden_dirs=True, ignore_hidden_files=True
     )
-    assert hash_value(tmpdir, tp=Directory) == helpers_file.hash_dir(tmpdir)
+    nohiddendirs_hash = helpers_file.hash_dir(tmpdir, ignore_hidden_dirs=True)
+    nohiddenfiles_hash = helpers_file.hash_dir(tmpdir, ignore_hidden_files=True)
+
+    assert orig_hash != nohidden_hash
+    assert orig_hash != nohiddendirs_hash
+    assert orig_hash != nohiddenfiles_hash
+
+    file_3.remove()
+    assert helpers_file.hash_dir(tmpdir) == nohiddenfiles_hash
+    hidden.remove()
+    assert helpers_file.hash_dir(tmpdir) == nohidden_hash
 
 
 def test_get_available_cpus():

--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -361,6 +361,18 @@ def test_task_nostate_1(plugin_dask_opt):
     # checking the results
     results = nn.result()
     assert results.output.out == 5
+    # checking the return_inputs option, either is return_inputs is True, or "val",
+    # it should give values of inputs that corresponds to the specific element
+    results_verb = nn.result(return_inputs=True)
+    results_verb_val = nn.result(return_inputs="val")
+    assert results_verb[0] == results_verb_val[0] == {"NA.a": 3}
+    assert results_verb[1].output.out == results_verb_val[1].output.out == 5
+    # checking the return_inputs option return_inputs="ind"
+    # it should give indices of inputs (instead of values) for each element
+    results_verb_ind = nn.result(return_inputs="ind")
+    assert results_verb_ind[0] == {"NA.a": None}
+    assert results_verb_ind[1].output.out == 5
+
     # checking the output_dir
     assert nn.output_dir.exists()
 
@@ -690,6 +702,22 @@ def test_task_state_1(plugin_dask_opt):
     expected = [({"NA.a": 3}, 5), ({"NA.a": 5}, 7)]
     for i, res in enumerate(expected):
         assert results[i].output.out == res[1]
+
+    # checking the return_inputs option, either return_inputs is True or "val",
+    # it should give values of inputs that corresponds to the specific element
+    results_verb = nn.result(return_inputs=True)
+    results_verb_val = nn.result(return_inputs="val")
+    for i, res in enumerate(expected):
+        assert (results_verb[i][0], results_verb[i][1].output.out) == res
+        assert (results_verb_val[i][0], results_verb_val[i][1].output.out) == res
+
+    # checking the return_inputs option return_inputs="ind"
+    # it should give indices of inputs (instead of values) for each element
+    results_verb_ind = nn.result(return_inputs="ind")
+    expected_ind = [({"NA.a": 0}, 5), ({"NA.a": 1}, 7)]
+    for i, res in enumerate(expected_ind):
+        assert (results_verb_ind[i][0], results_verb_ind[i][1].output.out) == res
+
     # checking the output_dir
     assert nn.output_dir
     for odir in nn.output_dir:
@@ -717,13 +745,14 @@ def test_task_state_1a(plugin_dask_opt):
 
 
 @pytest.mark.parametrize(
-    "splitter, state_splitter, state_rpn, expected",
+    "splitter, state_splitter, state_rpn, expected, expected_ind",
     [
         (
             ("a", "b"),
             ("NA.a", "NA.b"),
             ["NA.a", "NA.b", "."],
             [({"NA.a": 3, "NA.b": 10}, 13), ({"NA.a": 5, "NA.b": 20}, 25)],
+            [({"NA.a": 0, "NA.b": 0}, 13), ({"NA.a": 1, "NA.b": 1}, 25)],
         ),
         (
             ["a", "b"],
@@ -735,10 +764,18 @@ def test_task_state_1a(plugin_dask_opt):
                 ({"NA.a": 5, "NA.b": 10}, 15),
                 ({"NA.a": 5, "NA.b": 20}, 25),
             ],
+            [
+                ({"NA.a": 0, "NA.b": 0}, 13),
+                ({"NA.a": 0, "NA.b": 1}, 23),
+                ({"NA.a": 1, "NA.b": 0}, 15),
+                ({"NA.a": 1, "NA.b": 1}, 25),
+            ],
         ),
     ],
 )
-def test_task_state_2(plugin_dask_opt, splitter, state_splitter, state_rpn, expected):
+def test_task_state_2(
+    plugin_dask_opt, splitter, state_splitter, state_rpn, expected, expected_ind
+):
     """ Tasks with two inputs and a splitter (no combiner)"""
     nn = fun_addvar(name="NA").split(splitter=splitter, a=[3, 5], b=[10, 20])
 
@@ -756,6 +793,21 @@ def test_task_state_2(plugin_dask_opt, splitter, state_splitter, state_rpn, expe
     results = nn.result()
     for i, res in enumerate(expected):
         assert results[i].output.out == res[1]
+
+    # checking the return_inputs option, either return_inputs is True or "val",
+    # it should give values of inputs that corresponds to the specific element
+    results_verb = nn.result(return_inputs=True)
+    results_verb_val = nn.result(return_inputs="val")
+    for i, res in enumerate(expected):
+        assert (results_verb[i][0], results_verb[i][1].output.out) == res
+        assert (results_verb_val[i][0], results_verb_val[i][1].output.out) == res
+
+    # checking the return_inputs option return_inputs="ind"
+    # it should give indices of inputs (instead of values) for each element
+    results_verb_ind = nn.result(return_inputs="ind")
+    for i, res in enumerate(expected_ind):
+        assert (results_verb_ind[i][0], results_verb_ind[i][1].output.out) == res
+
     # checking the output_dir
     assert nn.output_dir
     for odir in nn.output_dir:
@@ -952,11 +1004,25 @@ def test_task_state_comb_1(plugin_dask_opt):
 
     # checking the results
     results = nn.result()
-
     # fully combined (no nested list)
     combined_results = [res.output.out for res in results]
-
     assert combined_results == [5, 7]
+
+    expected = [({"NA.a": 3}, 5), ({"NA.a": 5}, 7)]
+    expected_ind = [({"NA.a": 0}, 5), ({"NA.a": 1}, 7)]
+    # checking the return_inputs option, either return_inputs is True or "val",
+    # it should give values of inputs that corresponds to the specific element
+    results_verb = nn.result(return_inputs=True)
+    results_verb_val = nn.result(return_inputs="val")
+    for i, res in enumerate(expected):
+        assert (results_verb[i][0], results_verb[i][1].output.out) == res
+        assert (results_verb_val[i][0], results_verb_val[i][1].output.out) == res
+    # checking the return_inputs option return_inputs="ind"
+    # it should give indices of inputs (instead of values) for each element
+    results_verb_ind = nn.result(return_inputs="ind")
+    for i, res in enumerate(expected_ind):
+        assert (results_verb_ind[i][0], results_verb_ind[i][1].output.out) == res
+
     # checking the output_dir
     assert nn.output_dir
     for odir in nn.output_dir:
@@ -965,7 +1031,7 @@ def test_task_state_comb_1(plugin_dask_opt):
 
 @pytest.mark.parametrize(
     "splitter, combiner, state_splitter, state_rpn, state_combiner, state_combiner_all, "
-    "state_splitter_final, state_rpn_final, expected",
+    "state_splitter_final, state_rpn_final, expected, expected_val",
     [
         (
             ("a", "b"),
@@ -976,7 +1042,8 @@ def test_task_state_comb_1(plugin_dask_opt):
             ["NA.a", "NA.b"],
             None,
             [],
-            [({}, [13, 25])],
+            [13, 25],
+            [({"NA.a": 3, "NA.b": 10}, 13), ({"NA.a": 5, "NA.b": 20}, 25)],
         ),
         (
             ("a", "b"),
@@ -987,7 +1054,8 @@ def test_task_state_comb_1(plugin_dask_opt):
             ["NA.a", "NA.b"],
             None,
             [],
-            [({}, [13, 25])],
+            [13, 25],
+            [({"NA.a": 3, "NA.b": 10}, 13), ({"NA.a": 5, "NA.b": 20}, 25)],
         ),
         (
             ["a", "b"],
@@ -998,7 +1066,11 @@ def test_task_state_comb_1(plugin_dask_opt):
             ["NA.a"],
             "NA.b",
             ["NA.b"],
-            [({"NA.b": 10}, [13, 15]), ({"NA.b": 20}, [23, 25])],
+            [[13, 15], [23, 25]],
+            [
+                [({"NA.a": 3, "NA.b": 10}, 13), ({"NA.a": 5, "NA.b": 10}, 15)],
+                [({"NA.a": 3, "NA.b": 20}, 23), ({"NA.a": 5, "NA.b": 20}, 25)],
+            ],
         ),
         (
             ["a", "b"],
@@ -1009,7 +1081,11 @@ def test_task_state_comb_1(plugin_dask_opt):
             ["NA.b"],
             "NA.a",
             ["NA.a"],
-            [({"NA.a": 3}, [13, 23]), ({"NA.a": 5}, [15, 25])],
+            [[13, 23], [15, 25]],
+            [
+                [({"NA.a": 3, "NA.b": 10}, 13), ({"NA.a": 3, "NA.b": 20}, 23)],
+                [({"NA.a": 5, "NA.b": 10}, 15), ({"NA.a": 5, "NA.b": 20}, 25)],
+            ],
         ),
         (
             ["a", "b"],
@@ -1020,7 +1096,13 @@ def test_task_state_comb_1(plugin_dask_opt):
             ["NA.a", "NA.b"],
             None,
             [],
-            [({}, [13, 23, 15, 25])],
+            [13, 23, 15, 25],
+            [
+                ({"NA.a": 3, "NA.b": 10}, 13),
+                ({"NA.a": 3, "NA.b": 20}, 23),
+                ({"NA.a": 5, "NA.b": 10}, 15),
+                ({"NA.a": 5, "NA.b": 20}, 25),
+            ],
         ),
     ],
 )
@@ -1035,6 +1117,7 @@ def test_task_state_comb_2(
     state_splitter_final,
     state_rpn_final,
     expected,
+    expected_val,
 ):
     """ Tasks with scalar and outer splitters and  partial or full combiners"""
     nn = (
@@ -1049,19 +1132,32 @@ def test_task_state_comb_2(
     assert nn.state.splitter_rpn == state_rpn
     assert nn.state.combiner == state_combiner
 
+    with Submitter(plugin=plugin) as sub:
+        sub(nn)
+
     assert nn.state.splitter_final == state_splitter_final
     assert nn.state.splitter_rpn_final == state_rpn_final
     assert set(nn.state.right_combiner_all) == set(state_combiner_all)
 
-    with Submitter(plugin=plugin) as sub:
-        sub(nn)
-
     # checking the results
     results = nn.result()
+    # checking the return_inputs option, either return_inputs is True or "val",
+    # it should give values of inputs that corresponds to the specific element
+    results_verb = nn.result(return_inputs=True)
 
-    combined_results = [[res.output.out for res in res_l] for res_l in results]
-    for i, res in enumerate(expected):
-        assert combined_results[i] == res[1]
+    if nn.state.splitter_rpn_final:
+        for i, res in enumerate(expected):
+            assert [res.output.out for res in results[i]] == res
+        # results_verb
+        for i, res_l in enumerate(expected_val):
+            for j, res in enumerate(res_l):
+                assert (results_verb[i][j][0], results_verb[i][j][1].output.out) == res
+    # if the combiner is full expected is "a flat list"
+    else:
+        assert [res.output.out for res in results] == expected
+        for i, res in enumerate(expected_val):
+            assert (results_verb[i][0], results_verb[i][1].output.out) == res
+
     # checking the output_dir
     assert nn.output_dir
     for odir in nn.output_dir:
@@ -1097,7 +1193,7 @@ def test_task_state_comb_singl_1(plugin_dask_opt):
         assert odir.exists()
 
 
-def test_task_state_comb_2(plugin):
+def test_task_state_comb_3(plugin):
     """ task with the simplest splitter, the input is an empty list"""
     nn = fun_addtwo(name="NA").split(splitter="a", a=[]).combine(combiner=["a"])
 

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -16,11 +16,6 @@ from ..specs import ShellOutSpec, ShellSpec, SpecInfo, File
 if sys.platform.startswith("win"):
     pytest.skip("SLURM not available in windows", allow_module_level=True)
 
-if bool(shutil.which("sbatch")):
-    Plugins = ["cf", "dask", "slurm"]
-else:
-    Plugins = ["cf", "dask"]
-
 
 def result_no_submitter(shell_task, plugin=None):
     """ helper function to return result when running without submitter """
@@ -37,21 +32,19 @@ def result_submitter(shell_task, plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
-def test_shell_cmd_1(plugin, results_function):
+def test_shell_cmd_1(plugin_dask_opt, results_function):
     """ simple command, no arguments """
     cmd = ["pwd"]
     shelly = ShellCommandTask(name="shelly", executable=cmd)
     assert shelly.cmdline == " ".join(cmd)
 
-    res = results_function(shelly, plugin=plugin)
+    res = results_function(shelly, plugin=plugin_dask_opt)
     assert Path(res.output.stdout.rstrip()) == shelly.output_dir
     assert res.output.return_code == 0
     assert res.output.stderr == ""
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_1_strip(plugin, results_function):
     """ simple command, no arguments
         strip option to remove \n at the end os stdout
@@ -67,7 +60,6 @@ def test_shell_cmd_1_strip(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_2(plugin, results_function):
     """ a command with arguments, cmd and args given as executable """
     cmd = ["echo", "hail", "pydra"]
@@ -81,7 +73,6 @@ def test_shell_cmd_2(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_2a(plugin, results_function):
     """ a command with arguments, using executable and args """
     cmd_exec = "echo"
@@ -98,7 +89,6 @@ def test_shell_cmd_2a(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_2b(plugin, results_function):
     """ a command with arguments, using  strings executable and args """
     cmd_exec = "echo"
@@ -117,8 +107,7 @@ def test_shell_cmd_2b(plugin, results_function):
 # tests with State
 
 
-@pytest.mark.parametrize("plugin", Plugins)
-def test_shell_cmd_3(plugin):
+def test_shell_cmd_3(plugin_dask_opt):
     """ commands without arguments
         splitter = executable
     """
@@ -127,7 +116,7 @@ def test_shell_cmd_3(plugin):
     # all args given as executable
     shelly = ShellCommandTask(name="shelly", executable=cmd).split("executable")
     assert shelly.cmdline == ["pwd", "whoami"]
-    res = shelly(plugin=plugin)
+    res = shelly(plugin=plugin_dask_opt)
     assert Path(res[0].output.stdout.rstrip()) == shelly.output_dir[0]
 
     if "USER" in os.environ:
@@ -138,7 +127,6 @@ def test_shell_cmd_3(plugin):
     assert res[0].output.stderr == res[1].output.stderr == ""
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_4(plugin):
     """ a command with arguments, using executable and args
         splitter=args
@@ -161,7 +149,6 @@ def test_shell_cmd_4(plugin):
     assert res[0].output.stderr == res[1].output.stderr == ""
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_5(plugin):
     """ a command with arguments
         using splitter and combiner for args
@@ -183,7 +170,6 @@ def test_shell_cmd_5(plugin):
     assert res[1].output.stdout == "pydra\n"
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_6(plugin):
     """ a command with arguments,
         outer splitter for executable and args
@@ -225,7 +211,6 @@ def test_shell_cmd_6(plugin):
     )
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_7(plugin):
     """ a command with arguments,
         outer splitter for executable and args, and combiner=args
@@ -253,7 +238,6 @@ def test_shell_cmd_7(plugin):
 # tests with workflows
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_shell_cmd_1(plugin):
     """ a workflow with two connected commands"""
     wf = Workflow(name="wf", input_spec=["cmd1", "cmd2"])
@@ -280,7 +264,6 @@ def test_wf_shell_cmd_1(plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_1(plugin, results_function):
     """ a command with executable, args and one command opt,
         using a customized input_spec to add the opt to the command
@@ -320,7 +303,6 @@ def test_shell_cmd_inputspec_1(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_2(plugin, results_function):
     """ a command with executable, args and two command options,
         using a customized input_spec to add the opt to the command
@@ -365,7 +347,6 @@ def test_shell_cmd_inputspec_2(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_3(plugin, results_function):
     """  mandatory field added to fields, value provided """
     cmd_exec = "echo"
@@ -395,7 +376,6 @@ def test_shell_cmd_inputspec_3(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_3a(plugin, results_function):
     """  mandatory field added to fields, value provided
         using shorter syntax for input spec (no attr.ib)
@@ -421,7 +401,6 @@ def test_shell_cmd_inputspec_3a(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_3b(plugin, results_function):
     """  mandatory field added to fields, value provided after init"""
     cmd_exec = "echo"
@@ -451,7 +430,6 @@ def test_shell_cmd_inputspec_3b(plugin, results_function):
     assert res.output.stdout == "HELLO\n"
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_3c_exception(plugin):
     """  mandatory field added to fields, value is not provided, so exception is raised """
     cmd_exec = "echo"
@@ -478,7 +456,6 @@ def test_shell_cmd_inputspec_3c_exception(plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_3c(plugin, results_function):
     """  mandatory=False, so tasks runs fine even without the value """
     cmd_exec = "echo"
@@ -508,7 +485,6 @@ def test_shell_cmd_inputspec_3c(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_4(plugin, results_function):
     """  mandatory field added to fields, value provided """
     cmd_exec = "echo"
@@ -540,7 +516,6 @@ def test_shell_cmd_inputspec_4(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_4a(plugin, results_function):
     """  mandatory field added to fields, value provided
         using shorter syntax for input spec (no attr.ib)
@@ -565,7 +540,6 @@ def test_shell_cmd_inputspec_4a(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_4b(plugin, results_function):
     """  mandatory field added to fields, value provided """
     cmd_exec = "echo"
@@ -596,7 +570,6 @@ def test_shell_cmd_inputspec_4b(plugin, results_function):
     assert res.output.stdout == "Hi\n"
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_4c_exception(plugin):
     """  mandatory field added to fields, value provided """
     cmd_exec = "echo"
@@ -626,7 +599,6 @@ def test_shell_cmd_inputspec_4c_exception(plugin):
     )
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_4d_exception(plugin):
     """  mandatory field added to fields, value provided """
     cmd_exec = "echo"
@@ -661,7 +633,6 @@ def test_shell_cmd_inputspec_4d_exception(plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_5_nosubm(plugin, results_function):
     """ checking xor in metadata: task should work fine, since only one option is True"""
     cmd_exec = "ls"
@@ -706,7 +677,6 @@ def test_shell_cmd_inputspec_5_nosubm(plugin, results_function):
     res = results_function(shelly, plugin)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_5a_exception(plugin):
     """ checking xor in metadata: both options are True, so the task raises exception"""
     cmd_exec = "ls"
@@ -756,7 +726,6 @@ def test_shell_cmd_inputspec_5a_exception(plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_6(plugin, results_function):
     """ checking requires in metadata:
         the required field is set in the init, so the task works fine
@@ -803,7 +772,6 @@ def test_shell_cmd_inputspec_6(plugin, results_function):
     res = results_function(shelly, plugin)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_6a_exception(plugin):
     """ checking requires in metadata:
         the required field is None, so the task works raises exception
@@ -845,7 +813,6 @@ def test_shell_cmd_inputspec_6a_exception(plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_6b(plugin, results_function):
     """ checking requires in metadata:
         the required field set after the init
@@ -894,7 +861,6 @@ def test_shell_cmd_inputspec_6b(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_7(plugin, results_function):
     """
         providing output name using input_spec,
@@ -930,7 +896,6 @@ def test_shell_cmd_inputspec_7(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_7a(plugin, results_function):
     """
         providing output name using input_spec,
@@ -968,7 +933,6 @@ def test_shell_cmd_inputspec_7a(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_8(plugin, results_function, tmpdir):
     """ using input_spec, providing list of files as an input """
 
@@ -1010,7 +974,6 @@ def test_shell_cmd_inputspec_8(plugin, results_function, tmpdir):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_copyfile_1(plugin, results_function, tmpdir):
     """ shelltask changes a file in place,
         adding copyfile=True to the file-input from input_spec
@@ -1068,7 +1031,6 @@ def test_shell_cmd_inputspec_copyfile_1(plugin, results_function, tmpdir):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_copyfile_1a(plugin, results_function, tmpdir):
     """ shelltask changes a file in place,
         adding copyfile=False to the File-input from input_spec
@@ -1142,7 +1104,6 @@ def test_shell_cmd_inputspec_copyfile_1a(plugin, results_function, tmpdir):
     " and the results cant be found"
 )
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_copyfile_1b(plugin, results_function, tmpdir):
     """ shelltask changes a file in place,
         copyfile is None for the file-input, so original filed is changed
@@ -1195,7 +1156,6 @@ def test_shell_cmd_inputspec_copyfile_1b(plugin, results_function, tmpdir):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_state_1(plugin, results_function):
     """  adding state to the input from input_spec """
     cmd_exec = "echo"
@@ -1227,7 +1187,6 @@ def test_shell_cmd_inputspec_state_1(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_state_1a(plugin, results_function):
     """  adding state to the input from input_spec
         using shorter syntax for input_spec (without default)
@@ -1254,7 +1213,6 @@ def test_shell_cmd_inputspec_state_1a(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_state_2(plugin, results_function):
     """
         adding splitter to input tha is used in the output_file_tamplate
@@ -1290,7 +1248,6 @@ def test_shell_cmd_inputspec_state_2(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_state_3(plugin, results_function, tmpdir):
     """  adding state to the File-input from input_spec """
 
@@ -1331,7 +1288,6 @@ def test_shell_cmd_inputspec_state_3(plugin, results_function, tmpdir):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_inputspec_copyfile_state_1(plugin, results_function, tmpdir):
     """  adding state to the File-input from input_spec """
 
@@ -1396,8 +1352,7 @@ def test_shell_cmd_inputspec_copyfile_state_1(plugin, results_function, tmpdir):
 # customised input_spec in Workflow
 
 
-@pytest.mark.parametrize("plugin", Plugins)
-def test_wf_shell_cmd_2(plugin):
+def test_wf_shell_cmd_2(plugin_dask_opt):
     """ a workflow with input with defined output_file_template (str)
         that requires wf.lzin
     """
@@ -1434,7 +1389,7 @@ def test_wf_shell_cmd_2(plugin):
 
     wf.set_output([("out_f", wf.shelly.lzout.out1), ("out", wf.shelly.lzout.stdout)])
 
-    with Submitter(plugin=plugin) as sub:
+    with Submitter(plugin=plugin_dask_opt) as sub:
         wf(submitter=sub)
 
     res = wf.result()
@@ -1442,7 +1397,6 @@ def test_wf_shell_cmd_2(plugin):
     assert res.output.out_f.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_shell_cmd_2a(plugin):
     """ a workflow with input with defined output_file_template (tuple)
         that requires wf.lzin
@@ -1488,7 +1442,6 @@ def test_wf_shell_cmd_2a(plugin):
     assert res.output.out_f.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_shell_cmd_3(plugin):
     """ a workflow with 2 tasks,
         first one has input with output_file_template (str, uses wf.lzin),
@@ -1577,7 +1530,6 @@ def test_wf_shell_cmd_3(plugin):
     assert res.output.cp_file.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_shell_cmd_3a(plugin):
     """ a workflow with 2 tasks,
         first one has input with output_file_template (str, uses wf.lzin),
@@ -1666,8 +1618,7 @@ def test_wf_shell_cmd_3a(plugin):
     assert res.output.cp_file.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
-def test_wf_shell_cmd_state_1(plugin):
+def test_wf_shell_cmd_state_1(plugin_dask_opt):
     """ a workflow with 2 tasks and splitter on the wf level,
         first one has input with output_file_template (str, uses wf.lzin),
         that is passed to the second task
@@ -1745,7 +1696,7 @@ def test_wf_shell_cmd_state_1(plugin):
         ]
     )
 
-    with Submitter(plugin=plugin) as sub:
+    with Submitter(plugin=plugin_dask_opt) as sub:
         wf(submitter=sub)
 
     res_l = wf.result()
@@ -1756,8 +1707,7 @@ def test_wf_shell_cmd_state_1(plugin):
         assert res.output.cp_file.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
-def test_wf_shell_cmd_ndst_1(plugin):
+def test_wf_shell_cmd_ndst_1(plugin_dask_opt):
     """ a workflow with 2 tasks and a splitter on the node level,
         first one has input with output_file_template (str, uses wf.lzin),
         that is passed to the second task
@@ -1835,7 +1785,7 @@ def test_wf_shell_cmd_ndst_1(plugin):
         ]
     )
 
-    with Submitter(plugin=plugin) as sub:
+    with Submitter(plugin=plugin_dask_opt) as sub:
         wf(submitter=sub)
 
     res = wf.result()
@@ -1849,7 +1799,6 @@ def test_wf_shell_cmd_ndst_1(plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_1(plugin, results_function):
     """
         customised output_spec, adding files to the output, providing specific pathname
@@ -1868,7 +1817,6 @@ def test_shell_cmd_outputspec_1(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_1a(plugin, results_function):
     """
         customised output_spec, adding files to the output, providing specific pathname
@@ -1886,7 +1834,6 @@ def test_shell_cmd_outputspec_1a(plugin, results_function):
     assert res.output.newfile.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_1b_exception(plugin):
     """
         customised output_spec, adding files to the output, providing specific pathname
@@ -1906,7 +1853,6 @@ def test_shell_cmd_outputspec_1b_exception(plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_2(plugin, results_function):
     """
         customised output_spec, adding files to the output,
@@ -1925,7 +1871,6 @@ def test_shell_cmd_outputspec_2(plugin, results_function):
     assert res.output.newfile.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_2a_exception(plugin):
     """
         customised output_spec, adding files to the output,
@@ -1946,7 +1891,6 @@ def test_shell_cmd_outputspec_2a_exception(plugin):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_3(plugin, results_function):
     """
         customised output_spec, adding files to the output,
@@ -1968,7 +1912,6 @@ def test_shell_cmd_outputspec_3(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_4(plugin, results_function):
     """
         customised output_spec, adding files to the output,
@@ -1995,7 +1938,6 @@ def test_shell_cmd_outputspec_4(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_5(plugin, results_function):
     """
         providing output name by providing output_file_template
@@ -2031,7 +1973,6 @@ def test_shell_cmd_outputspec_5(plugin, results_function):
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_state_outputspec_1(plugin, results_function):
     """
         providing output name by providing output_file_template
@@ -2070,7 +2011,6 @@ def test_shell_cmd_state_outputspec_1(plugin, results_function):
 # customised output_spec for tasks in workflows
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_shell_cmd_outputspec_wf_1(plugin):
     """
         customised output_spec for tasks within a Workflow,

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -11,24 +11,11 @@ from ..task import ShellCommandTask
 from ..submitter import Submitter
 from ..core import Workflow
 from ..specs import ShellOutSpec, ShellSpec, SpecInfo, File
+from .utils import result_no_submitter, result_submitter
 
 
 if sys.platform.startswith("win"):
     pytest.skip("SLURM not available in windows", allow_module_level=True)
-
-
-def result_no_submitter(shell_task, plugin=None):
-    """ helper function to return result when running without submitter """
-    return shell_task()
-
-
-def result_submitter(shell_task, plugin):
-    """ helper function to return result when running with submitter
-        with specific plugin
-    """
-    with Submitter(plugin=plugin) as sub:
-        shell_task(submitter=sub)
-    return shell_task.result()
 
 
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])

--- a/pydra/engine/tests/test_shelltask.py
+++ b/pydra/engine/tests/test_shelltask.py
@@ -18,6 +18,7 @@ if sys.platform.startswith("win"):
     pytest.skip("SLURM not available in windows", allow_module_level=True)
 
 
+@pytest.mark.flaky(reruns=2)  # when dask
 @pytest.mark.parametrize("results_function", [result_no_submitter, result_submitter])
 def test_shell_cmd_1(plugin_dask_opt, results_function):
     """ simple command, no arguments """
@@ -94,6 +95,7 @@ def test_shell_cmd_2b(plugin, results_function):
 # tests with State
 
 
+@pytest.mark.flaky(reruns=2)
 def test_shell_cmd_3(plugin_dask_opt):
     """ commands without arguments
         splitter = executable
@@ -1339,6 +1341,7 @@ def test_shell_cmd_inputspec_copyfile_state_1(plugin, results_function, tmpdir):
 # customised input_spec in Workflow
 
 
+@pytest.mark.flaky(reruns=2)  # when dask
 def test_wf_shell_cmd_2(plugin_dask_opt):
     """ a workflow with input with defined output_file_template (str)
         that requires wf.lzin
@@ -1605,7 +1608,7 @@ def test_wf_shell_cmd_3a(plugin):
     assert res.output.cp_file.exists()
 
 
-def test_wf_shell_cmd_state_1(plugin_dask_opt):
+def test_wf_shell_cmd_state_1(plugin):
     """ a workflow with 2 tasks and splitter on the wf level,
         first one has input with output_file_template (str, uses wf.lzin),
         that is passed to the second task
@@ -1683,7 +1686,7 @@ def test_wf_shell_cmd_state_1(plugin_dask_opt):
         ]
     )
 
-    with Submitter(plugin=plugin_dask_opt) as sub:
+    with Submitter(plugin=plugin) as sub:
         wf(submitter=sub)
 
     res_l = wf.result()
@@ -1694,7 +1697,7 @@ def test_wf_shell_cmd_state_1(plugin_dask_opt):
         assert res.output.cp_file.exists()
 
 
-def test_wf_shell_cmd_ndst_1(plugin_dask_opt):
+def test_wf_shell_cmd_ndst_1(plugin):
     """ a workflow with 2 tasks and a splitter on the node level,
         first one has input with output_file_template (str, uses wf.lzin),
         that is passed to the second task
@@ -1772,7 +1775,7 @@ def test_wf_shell_cmd_ndst_1(plugin_dask_opt):
         ]
     )
 
-    with Submitter(plugin=plugin_dask_opt) as sub:
+    with Submitter(plugin=plugin) as sub:
         wf(submitter=sub)
 
     res = wf.result()

--- a/pydra/engine/tests/test_singularity.py
+++ b/pydra/engine/tests/test_singularity.py
@@ -10,11 +10,6 @@ from ..submitter import Submitter
 from ..core import Workflow
 from ..specs import ShellOutSpec, SpecInfo, File, SingularitySpec
 
-if bool(shutil.which("sbatch")):
-    Plugins = ["cf", "slurm"]
-else:
-    Plugins = ["cf"]
-
 
 need_docker = pytest.mark.skipif(
     shutil.which("docker") is None or sp.call(["docker", "info"]),
@@ -64,7 +59,6 @@ def test_singularity_2_nosubm(tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_2(plugin, tmpdir):
     """ a command with arguments, cmd and args given as executable
         using submitter
@@ -85,7 +79,6 @@ def test_singularity_2(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_2_singuflag(plugin, tmpdir):
     """ a command with arguments, cmd and args given as executable
         using ShellComandTask with container_info=("singularity", image)
@@ -111,7 +104,6 @@ def test_singularity_2_singuflag(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_2a(plugin, tmpdir):
     """ a command with arguments, using executable and args
         using submitter
@@ -136,7 +128,6 @@ def test_singularity_2a(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_3(plugin, tmpdir):
     """ a simple command in container with bindings,
         creating directory in tmp dir and checking if it is in the container
@@ -158,7 +149,6 @@ def test_singularity_3(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_3_singuflag(plugin, tmpdir):
     """ a simple command in container with bindings,
         creating directory in tmp dir and checking if it is in the container
@@ -186,7 +176,6 @@ def test_singularity_3_singuflag(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_3_singuflagbind(plugin, tmpdir):
     """ a simple command in container with bindings,
         creating directory in tmp dir and checking if it is in the container
@@ -215,7 +204,6 @@ def test_singularity_3_singuflagbind(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_st_1(plugin, tmpdir):
     """ commands without arguments in container
         splitter = executable
@@ -234,7 +222,6 @@ def test_singularity_st_1(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_st_2(plugin, tmpdir):
     """ command with arguments in docker, checking the distribution
         splitter = image
@@ -253,7 +240,6 @@ def test_singularity_st_2(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_st_3(plugin, tmpdir):
     """ outer splitter image and executable
     """
@@ -272,7 +258,6 @@ def test_singularity_st_3(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_singularity_1(plugin, tmpdir):
     """ a workflow with two connected task
         the first one read the file that is bounded to the container,
@@ -314,7 +299,6 @@ def test_wf_singularity_1(plugin, tmpdir):
 
 @need_docker
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_singularity_1a(plugin, tmpdir):
     """ a workflow with two connected task - using both containers: Docker and Singul.
         the first one read the file that is bounded to the container,
@@ -359,7 +343,6 @@ def test_wf_singularity_1a(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_outputspec_1(plugin, tmpdir):
     """
         customised output_spec, adding files to the output, providing specific pathname
@@ -393,7 +376,6 @@ def test_singularity_outputspec_1(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_inputspec_1(plugin, tmpdir):
     """ a simple customized input spec for singularity task """
     filename = str(tmpdir.join("file_pydra.txt"))
@@ -436,7 +418,6 @@ def test_singularity_inputspec_1(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_inputspec_1a(plugin, tmpdir):
     """ a simple customized input spec for singularity task
         a default value is used
@@ -477,7 +458,6 @@ def test_singularity_inputspec_1a(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_inputspec_2(plugin, tmpdir):
     """ a customized input spec with two fields for singularity task """
     filename_1 = tmpdir.join("file_pydra.txt")
@@ -527,7 +507,6 @@ def test_singularity_inputspec_2(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_inputspec_2a_except(plugin, tmpdir):
     """ a customized input spec with two fields
         first one uses a default, and second doesn't - raises a dataclass exception
@@ -578,7 +557,6 @@ def test_singularity_inputspec_2a_except(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_inputspec_2a(plugin, tmpdir):
     """ a customized input spec with two fields
         first one uses a default value,
@@ -631,7 +609,6 @@ def test_singularity_inputspec_2a(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_cmd_inputspec_copyfile_1(plugin, tmpdir):
     """ shelltask changes a file in place,
         adding copyfile=True to the file-input from input_spec
@@ -695,7 +672,6 @@ def test_singularity_cmd_inputspec_copyfile_1(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_inputspec_state_1(plugin, tmpdir):
     """ a customised input spec for a singularity file with a splitter,
         splitter is on files
@@ -745,7 +721,6 @@ def test_singularity_inputspec_state_1(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_inputspec_state_1b(plugin, tmpdir):
     """ a customised input spec for a singularity file with a splitter,
         files from the input spec have the same path in the local os and the container,
@@ -796,7 +771,6 @@ def test_singularity_inputspec_state_1b(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_wf_inputspec_1(plugin, tmpdir):
     """ a customized input spec for workflow with singularity tasks """
     filename = tmpdir.join("file_pydra.txt")
@@ -848,7 +822,6 @@ def test_singularity_wf_inputspec_1(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_wf_state_inputspec_1(plugin, tmpdir):
     """ a customized input spec for workflow with singularity tasks that has a state"""
     file_1 = tmpdir.join("file_pydra.txt")
@@ -906,7 +879,6 @@ def test_singularity_wf_state_inputspec_1(plugin, tmpdir):
 
 
 @need_singularity
-@pytest.mark.parametrize("plugin", Plugins)
 def test_singularity_wf_ndst_inputspec_1(plugin, tmpdir):
     """ a customized input spec for workflow with singularity tasks with states"""
     file_1 = tmpdir.join("file_pydra.txt")

--- a/pydra/engine/tests/test_submitter.py
+++ b/pydra/engine/tests/test_submitter.py
@@ -103,6 +103,7 @@ def test_wf_in_wf(plugin):
     assert res.output.out == 7
 
 
+@pytest.mark.flaky(reruns=2)  # when dask
 def test_wf2(plugin_dask_opt):
     """ workflow as a node
         workflow-node with one task and no splitter
@@ -123,6 +124,7 @@ def test_wf2(plugin_dask_opt):
     assert res.output.out == 3
 
 
+@pytest.mark.flaky(reruns=2)  # when dask
 def test_wf_with_state(plugin_dask_opt):
     wf = Workflow(name="wf_with_state", input_spec=["x"])
     wf.add(sleep_add_one(name="taska", x=wf.lzin.x))

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -535,7 +535,7 @@ def test_wf_ndst_2(plugin):
 
 def test_wf_st_3(plugin):
     """ workflow with 2 tasks, splitter on wf level"""
-    wf = Workflow(name="wf_st_3", input_spec=["x", "y"])
+    wf = Workflow(name="wfst_3", input_spec=["x", "y"])
     wf.add(multiply(name="mult", x=wf.lzin.x, y=wf.lzin.y))
     wf.add(add2(name="add2", x=wf.mult.lzout.out))
     wf.inputs.x = [1, 2]
@@ -547,10 +547,33 @@ def test_wf_st_3(plugin):
     with Submitter(plugin=plugin) as sub:
         sub(wf)
 
+    expected = [
+        ({"wfst_3.x": 1, "wfst_3.y": 11}, 13),
+        ({"wfst_3.x": 2, "wfst_3.y": 12}, 26),
+    ]
+    expected_ind = [
+        ({"wfst_3.x": 0, "wfst_3.y": 0}, 13),
+        ({"wfst_3.x": 1, "wfst_3.y": 1}, 26),
+    ]
+
     results = wf.result()
-    # expected: [({"test7.x": 1, "test7.y": 11}, 13), ({"test7.x": 2, "test.y": 12}, 26)]
-    assert results[0].output.out == 13
-    assert results[1].output.out == 26
+    for i, res in enumerate(expected):
+        assert results[i].output.out == res[1]
+
+    # checking the return_inputs option, either return_inputs is True or "val",
+    # it should give values of inputs that corresponds to the specific element
+    results_verb = wf.result(return_inputs=True)
+    results_verb_val = wf.result(return_inputs="val")
+    for i, res in enumerate(expected):
+        assert (results_verb[i][0], results_verb[i][1].output.out) == res
+        assert (results_verb_val[i][0], results_verb_val[i][1].output.out) == res
+
+    # checking the return_inputs option return_inputs="ind"
+    # it should give indices of inputs (instead of values) for each element
+    results_verb_ind = wf.result(return_inputs="ind")
+    for i, res in enumerate(expected_ind):
+        assert (results_verb_ind[i][0], results_verb_ind[i][1].output.out) == res
+
     # checking all directories
     assert wf.output_dir
     for odir in wf.output_dir:

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -23,23 +23,17 @@ from .utils import (
 from ..submitter import Submitter
 from ..core import Workflow
 
-if bool(shutil.which("sbatch")):
-    Plugins = ["cf", "dask", "slurm"]
-else:
-    Plugins = ["cf", "dask"]
 
-
-@pytest.mark.parametrize("plugin", Plugins)
-def test_wf_1(plugin):
+def test_wf_1(plugin_dask_opt):
     """ workflow with one task and no splitter"""
     wf = Workflow(name="wf_1", input_spec=["x"])
     wf.add(add2(name="add2", x=wf.lzin.x))
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
-    wf.plugin = plugin
+    wf.plugin = plugin_dask_opt
 
     checksum_before = wf.checksum
-    with Submitter(plugin=plugin) as sub:
+    with Submitter(plugin=plugin_dask_opt) as sub:
         sub(wf)
 
     assert wf.checksum == checksum_before
@@ -48,7 +42,6 @@ def test_wf_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_1a_outpastuple(plugin):
     """ workflow with one task and no splitter
         set_output takes a tuple
@@ -67,14 +60,12 @@ def test_wf_1a_outpastuple(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_1_call_subm(plugin):
     """using wf.__call_ with submitter"""
     wf = Workflow(name="wf_1", input_spec=["x"])
     wf.add(add2(name="add2", x=wf.lzin.x))
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
-    wf.plugin = plugin
 
     with Submitter(plugin=plugin) as sub:
         wf(submitter=sub)
@@ -84,7 +75,6 @@ def test_wf_1_call_subm(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_1_call_plug(plugin):
     """using wf.__call_ with plugin"""
     wf = Workflow(name="wf_1", input_spec=["x"])
@@ -100,7 +90,6 @@ def test_wf_1_call_plug(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_1_call_exception(plugin):
     """using wf.__call_ with plugin and submitter - should raise an exception"""
     wf = Workflow(name="wf_1", input_spec=["x"])
@@ -115,7 +104,6 @@ def test_wf_1_call_exception(plugin):
         assert "Specify submitter OR plugin" in str(e.value)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_2(plugin):
     """ workflow with 2 tasks, no splitter"""
     wf = Workflow(name="wf_2", input_spec=["x", "y"])
@@ -134,7 +122,6 @@ def test_wf_2(plugin):
     assert 8 == results.output.out
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_2a(plugin):
     """ workflow with 2 tasks, no splitter
         creating add2_task first (before calling add method),
@@ -157,7 +144,6 @@ def test_wf_2a(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_2b(plugin):
     """ workflow with 2 tasks, no splitter
         creating add2_task first (before calling add method),
@@ -182,7 +168,6 @@ def test_wf_2b(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_2c_multoutp(plugin):
     """ workflow with 2 tasks, no splitter
         setting multiple outputs for the workflow
@@ -208,7 +193,6 @@ def test_wf_2c_multoutp(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_2d_outpasdict(plugin):
     """ workflow with 2 tasks, no splitter
         setting multiple outputs using a dictionary
@@ -234,8 +218,7 @@ def test_wf_2d_outpasdict(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
-def test_wf_3(plugin):
+def test_wf_3(plugin_dask_opt):
     """ testing None value for an input"""
     wf = Workflow(name="wf_3", input_spec=["x", "y"])
     wf.add(fun_addvar_none(name="addvar", a=wf.lzin.x, b=wf.lzin.y))
@@ -243,9 +226,9 @@ def test_wf_3(plugin):
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
     wf.inputs.y = None
-    wf.plugin = plugin
+    wf.plugin = plugin_dask_opt
 
-    with Submitter(plugin=plugin) as sub:
+    with Submitter(plugin=plugin_dask_opt) as sub:
         sub(wf)
 
     assert wf.output_dir.exists()
@@ -254,7 +237,6 @@ def test_wf_3(plugin):
 
 
 @pytest.mark.xfail(reason="the task error doesn't propagate")
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3a_exception(plugin):
     """ testinh wf without set input, attr.NOTHING should be set
         and the function should raise an exception
@@ -273,7 +255,6 @@ def test_wf_3a_exception(plugin):
     assert "unsupported" in str(excinfo.value)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_4(plugin):
     """wf with a task that doesn't set one input and use the function default value"""
     wf = Workflow(name="wf_4", input_spec=["x", "y"])
@@ -291,7 +272,6 @@ def test_wf_4(plugin):
     assert 5 == results.output.out
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_4a(plugin):
     """ wf with a task that doesn't set one input,
         the unset input is send to the task input,
@@ -312,7 +292,6 @@ def test_wf_4a(plugin):
     assert 5 == results.output.out
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_1(plugin):
     """ Workflow with one task, a splitter for the workflow"""
     wf = Workflow(name="wf_spl_1", input_spec=["x"])
@@ -338,7 +317,6 @@ def test_wf_st_1(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_1_call_subm(plugin):
     """ Workflow with one task, a splitter for the workflow"""
     wf = Workflow(name="wf_spl_1", input_spec=["x"])
@@ -362,7 +340,6 @@ def test_wf_st_1_call_subm(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_1_call_plug(plugin):
     """ Workflow with one task, a splitter for the workflow"""
     wf = Workflow(name="wf_spl_1", input_spec=["x"])
@@ -385,7 +362,6 @@ def test_wf_st_1_call_plug(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_noinput_1(plugin):
     """ Workflow with one task, a splitter for the workflow"""
     wf = Workflow(name="wf_spl_1", input_spec=["x"])
@@ -407,7 +383,6 @@ def test_wf_st_noinput_1(plugin):
     assert wf.output_dir == []
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_1(plugin):
     """ workflow with one task, a splitter on the task level"""
     wf = Workflow(name="wf_spl_1", input_spec=["x"])
@@ -427,7 +402,6 @@ def test_wf_ndst_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_updatespl_1(plugin):
     """ workflow with one task,
         a splitter on the task level is added *after* calling add
@@ -450,7 +424,6 @@ def test_wf_ndst_updatespl_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_updatespl_1a(plugin):
     """ workflow with one task (initialize before calling add),
         a splitter on the task level is added *after* calling add
@@ -474,7 +447,6 @@ def test_wf_ndst_updatespl_1a(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_updateinp_1(plugin):
     """ workflow with one task,
         a splitter on the task level,
@@ -499,7 +471,6 @@ def test_wf_ndst_updateinp_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_noinput_1(plugin):
     """ workflow with one task, a splitter on the task level"""
     wf = Workflow(name="wf_spl_1", input_spec=["x"])
@@ -519,7 +490,6 @@ def test_wf_ndst_noinput_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_2(plugin):
     """ workflow with one task, splitters and combiner for workflow"""
     wf = Workflow(name="wf_st_2", input_spec=["x"])
@@ -543,7 +513,6 @@ def test_wf_st_2(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_2(plugin):
     """ workflow with one task, splitters and combiner on the task level"""
     wf = Workflow(name="wf_ndst_2", input_spec=["x"])
@@ -564,7 +533,6 @@ def test_wf_ndst_2(plugin):
 # workflows with structures A -> B
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_3(plugin):
     """ workflow with 2 tasks, splitter on wf level"""
     wf = Workflow(name="wf_st_3", input_spec=["x", "y"])
@@ -589,7 +557,6 @@ def test_wf_st_3(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_3(plugin):
     """Test workflow with 2 tasks, splitter on a task level"""
     wf = Workflow(name="wf_ndst_3", input_spec=["x", "y"])
@@ -610,7 +577,6 @@ def test_wf_ndst_3(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_4(plugin):
     """ workflow with two tasks, scalar splitter and combiner for the workflow"""
     wf = Workflow(name="wf_st_4", input_spec=["x", "y"])
@@ -637,7 +603,6 @@ def test_wf_st_4(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_4(plugin):
     """ workflow with two tasks, scalar splitter and combiner on tasks level"""
     wf = Workflow(name="wf_ndst_4", input_spec=["a", "b"])
@@ -661,7 +626,6 @@ def test_wf_ndst_4(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_5(plugin):
     """ workflow with two tasks, outer splitter and no combiner"""
     wf = Workflow(name="wf_st_5", input_spec=["x", "y"])
@@ -670,7 +634,6 @@ def test_wf_st_5(plugin):
 
     wf.split(["x", "y"], x=[1, 2], y=[11, 12])
     wf.set_output([("out", wf.add2.lzout.out)])
-    wf.plugin = plugin
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -686,7 +649,6 @@ def test_wf_st_5(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_5(plugin):
     """ workflow with two tasks, outer splitter on tasks level and no combiner"""
     wf = Workflow(name="wf_ndst_5", input_spec=["x", "y"])
@@ -695,7 +657,6 @@ def test_wf_ndst_5(plugin):
     wf.inputs.x = [1, 2]
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.add2.lzout.out)])
-    wf.plugin = plugin
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -709,7 +670,6 @@ def test_wf_ndst_5(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_6(plugin):
     """ workflow with two tasks, outer splitter and combiner for the workflow"""
     wf = Workflow(name="wf_st_6", input_spec=["x", "y"])
@@ -737,7 +697,6 @@ def test_wf_st_6(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_6(plugin):
     """ workflow with two tasks, outer splitter and combiner on tasks level"""
     wf = Workflow(name="wf_ndst_6", input_spec=["x", "y"])
@@ -759,7 +718,6 @@ def test_wf_ndst_6(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_7(plugin):
     """ workflow with two tasks, outer splitter and (full) combiner for first node only"""
     wf = Workflow(name="wf_ndst_6", input_spec=["x", "y"])
@@ -780,7 +738,6 @@ def test_wf_ndst_7(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_8(plugin):
     """ workflow with two tasks, outer splitter and (partial) combiner for first task only"""
     wf = Workflow(name="wf_ndst_6", input_spec=["x", "y"])
@@ -804,7 +761,6 @@ def test_wf_ndst_8(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_9(plugin):
     """ workflow with two tasks, outer splitter and (full) combiner for first task only"""
     wf = Workflow(name="wf_ndst_6", input_spec=["x", "y"])
@@ -832,7 +788,6 @@ def test_wf_ndst_9(plugin):
 # workflows with structures A ->  B -> C
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3sernd_ndst_1(plugin):
     """ workflow with three "serial" tasks, checking if the splitter is propagating"""
     wf = Workflow(name="wf_3sernd_ndst_1", input_spec=["x", "y"])
@@ -859,8 +814,7 @@ def test_wf_3sernd_ndst_1(plugin):
 # workflows with structures A -> C, B -> C
 
 
-@pytest.mark.parametrize("plugin", Plugins)
-def test_wf_3nd_st_1(plugin):
+def test_wf_3nd_st_1(plugin_dask_opt):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter on the workflow level
     """
@@ -871,9 +825,8 @@ def test_wf_3nd_st_1(plugin):
     wf.split(["x", "y"], x=[1, 2, 3], y=[11, 12])
 
     wf.set_output([("out", wf.mult.lzout.out)])
-    wf.plugin = plugin
 
-    with Submitter(plugin=plugin) as sub:
+    with Submitter(plugin=plugin_dask_opt) as sub:
         sub(wf)
 
     results = wf.result()
@@ -887,8 +840,7 @@ def test_wf_3nd_st_1(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
-def test_wf_3nd_ndst_1(plugin):
+def test_wf_3nd_ndst_1(plugin_dask_opt):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter on the tasks levels
     """
@@ -899,9 +851,8 @@ def test_wf_3nd_ndst_1(plugin):
     wf.inputs.x = [1, 2, 3]
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.mult.lzout.out)])
-    wf.plugin = plugin
 
-    with Submitter(plugin=plugin) as sub:
+    with Submitter(plugin=plugin_dask_opt) as sub:
         sub(wf)
 
     results = wf.result()
@@ -911,7 +862,6 @@ def test_wf_3nd_ndst_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3nd_st_2(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter and partial combiner on the workflow level
@@ -942,7 +892,6 @@ def test_wf_3nd_st_2(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3nd_ndst_2(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter and partial combiner on the tasks levels
@@ -971,7 +920,6 @@ def test_wf_3nd_ndst_2(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3nd_st_3(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter and partial combiner (from the second task) on the workflow level
@@ -983,7 +931,6 @@ def test_wf_3nd_st_3(plugin):
     wf.split(["x", "y"], x=[1, 2, 3], y=[11, 12]).combine("y")
 
     wf.set_output([("out", wf.mult.lzout.out)])
-    wf.plugin = plugin
 
     with Submitter(plugin=plugin) as sub:
         sub(wf)
@@ -1002,8 +949,7 @@ def test_wf_3nd_st_3(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
-def test_wf_3nd_ndst_3(plugin):
+def test_wf_3nd_ndst_3(plugin_dask_opt):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter and partial combiner (from the second task) on the tasks levels
     """
@@ -1018,9 +964,8 @@ def test_wf_3nd_ndst_3(plugin):
     wf.inputs.x = [1, 2, 3]
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.mult.lzout.out)])
-    wf.plugin = plugin
 
-    with Submitter(plugin=plugin) as sub:
+    with Submitter(plugin=plugin_dask_opt) as sub:
         sub(wf)
 
     results = wf.result()
@@ -1032,7 +977,6 @@ def test_wf_3nd_ndst_3(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3nd_st_4(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter and full combiner on the workflow level
@@ -1062,7 +1006,6 @@ def test_wf_3nd_st_4(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3nd_ndst_4(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter and full combiner on the tasks levels
@@ -1091,7 +1034,6 @@ def test_wf_3nd_ndst_4(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3nd_st_5(plugin):
     """ workflow with three tasks (A->C, B->C) and three fields in the splitter,
         splitter and partial combiner (from the second task) on the workflow level
@@ -1129,7 +1071,6 @@ def test_wf_3nd_st_5(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3nd_ndst_5(plugin):
     """ workflow with three tasks (A->C, B->C) and three fields in the splitter,
         all tasks have splitters and the last one has a partial combiner (from the 2nd)
@@ -1165,7 +1106,6 @@ def test_wf_3nd_ndst_5(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_3nd_ndst_6(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         the third one uses scalar splitter from the previous ones and a combiner
@@ -1195,7 +1135,6 @@ def test_wf_3nd_ndst_6(plugin):
 # workflows with Left and Right part in splitters A -> B (L&R parts of the splitter)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstLR_1(plugin):
     """ Test workflow with 2 tasks, splitters on tasks levels
         The second task has its own simple splitter
@@ -1224,7 +1163,6 @@ def test_wf_ndstLR_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstLR_1a(plugin):
     """ Test workflow with 2 tasks, splitters on tasks levels
         The second task has splitter that has Left part (from previous state)
@@ -1255,7 +1193,6 @@ def test_wf_ndstLR_1a(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstLR_2(plugin):
     """ Test workflow with 2 tasks, splitters on tasks levels
         The second task has its own outer splitter
@@ -1305,7 +1242,6 @@ def test_wf_ndstLR_2(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstLR_2a(plugin):
     """ Test workflow with 2 tasks, splitters on tasks levels
         The second task has splitter that has Left part (from previous state)
@@ -1358,7 +1294,6 @@ def test_wf_ndstLR_2a(plugin):
 # workflows with inner splitters A -> B (inner spl)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstinner_1(plugin):
     """ workflow with 2 tasks,
         the second task has inner splitter
@@ -1383,7 +1318,6 @@ def test_wf_ndstinner_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstinner_2(plugin):
     """ workflow with 2 tasks,
         the second task has two inputs and inner splitter from one of the input
@@ -1409,7 +1343,6 @@ def test_wf_ndstinner_2(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstinner_3(plugin):
     """ workflow with 2 tasks,
         the second task has two inputs and outer splitter that includes an inner field
@@ -1435,7 +1368,6 @@ def test_wf_ndstinner_3(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstinner_4(plugin):
     """ workflow with 3 tasks,
         the second task has two inputs and inner splitter from one of the input,
@@ -1468,7 +1400,6 @@ def test_wf_ndstinner_4(plugin):
 # workflow that have some single values as the input
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_singl_1(plugin):
     """ workflow with two tasks, only one input is in the splitter and combiner"""
     wf = Workflow(name="wf_st_5", input_spec=["x", "y"])
@@ -1492,7 +1423,6 @@ def test_wf_st_singl_1(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_singl_1(plugin):
     """ workflow with two tasks, outer splitter and combiner on tasks level;
         only one input is part of the splitter, the other is a single value
@@ -1514,7 +1444,6 @@ def test_wf_ndst_singl_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_st_singl_2(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter on the workflow level
@@ -1543,7 +1472,6 @@ def test_wf_st_singl_2(plugin):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndst_singl_2(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter on the tasks levels
@@ -1571,7 +1499,6 @@ def test_wf_ndst_singl_2(plugin):
 # workflows with structures wf(A)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_1(plugin):
     """ workflow as a node
         workflow-node with one task and no splitter
@@ -1595,7 +1522,6 @@ def test_wfasnd_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_wfinp_1(plugin):
     """ workflow as a node
         workflow-node with one task and no splitter
@@ -1622,7 +1548,6 @@ def test_wfasnd_wfinp_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_wfndupdate(plugin):
     """ workflow as a node
         workflow-node with one task and no splitter
@@ -1647,7 +1572,6 @@ def test_wfasnd_wfndupdate(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_wfndupdate_rerun(plugin):
     """ workflow as a node
         workflow-node with one task and no splitter
@@ -1692,7 +1616,6 @@ def test_wfasnd_wfndupdate_rerun(plugin):
     assert wf_o.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_st_1(plugin):
     """ workflow as a node
         workflow-node with one task,
@@ -1720,7 +1643,6 @@ def test_wfasnd_st_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_st_updatespl_1(plugin):
     """ workflow as a node
         workflow-node with one task,
@@ -1746,7 +1668,6 @@ def test_wfasnd_st_updatespl_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_ndst_1(plugin):
     """ workflow as a node
         workflow-node with one task,
@@ -1773,7 +1694,6 @@ def test_wfasnd_ndst_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_ndst_updatespl_1(plugin):
     """ workflow as a node
         workflow-node with one task,
@@ -1801,7 +1721,6 @@ def test_wfasnd_ndst_updatespl_1(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_wfst_1(plugin):
     """ workflow as a node
         workflow-node with one task,
@@ -1833,7 +1752,6 @@ def test_wfasnd_wfst_1(plugin):
 # workflows with structures wf(A) -> B
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_st_2(plugin):
     """ workflow as a node,
         the main workflow has two tasks,
@@ -1861,7 +1779,6 @@ def test_wfasnd_st_2(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_wfst_2(plugin):
     """ workflow as a node,
         the main workflow has two tasks,
@@ -1895,7 +1812,6 @@ def test_wfasnd_wfst_2(plugin):
 # workflows with structures A -> wf(B)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_ndst_3(plugin):
     """ workflow as the second node,
         the main workflow has two tasks,
@@ -1923,7 +1839,6 @@ def test_wfasnd_ndst_3(plugin):
     assert wf.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wfasnd_wfst_3(plugin):
     """ workflow as the second node,
         the main workflow has two tasks,
@@ -1958,7 +1873,6 @@ def test_wfasnd_wfst_3(plugin):
 # Testing caching
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachedir(plugin, tmpdir):
     """ wf with provided cache_dir using pytest tmpdir"""
     cache_dir = tmpdir.mkdir("test_wf_cache_1")
@@ -1981,7 +1895,6 @@ def test_wf_nostate_cachedir(plugin, tmpdir):
     shutil.rmtree(cache_dir)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachedir_relativepath(tmpdir, plugin):
     """ wf with provided cache_dir as relative path"""
     tmpdir.chdir()
@@ -2006,7 +1919,6 @@ def test_wf_nostate_cachedir_relativepath(tmpdir, plugin):
     shutil.rmtree(cache_dir)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachelocations(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir;
@@ -2061,7 +1973,6 @@ def test_wf_nostate_cachelocations(plugin, tmpdir):
     assert not wf2.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachelocations_forcererun(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir;
@@ -2117,7 +2028,6 @@ def test_wf_nostate_cachelocations_forcererun(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachelocations_wftaskrerun_propagateTrue(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir and cache_locations for the second one;
@@ -2176,7 +2086,6 @@ def test_wf_nostate_cachelocations_wftaskrerun_propagateTrue(plugin, tmpdir):
     assert t2 > 3
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachelocations_wftaskrerun_propagateFalse(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir and cache_locations for the second one;
@@ -2235,7 +2144,6 @@ def test_wf_nostate_cachelocations_wftaskrerun_propagateFalse(plugin, tmpdir):
     assert len(list(Path(cache_dir2).glob("F*"))) == 0
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachelocations_taskrerun_wfrerun_propagateFalse(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir, and cache_locations for teh second wf;
@@ -2295,7 +2203,6 @@ def test_wf_nostate_cachelocations_taskrerun_wfrerun_propagateFalse(plugin, tmpd
     assert t2 > 3
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_nodecachelocations(plugin, tmpdir):
     """
     Two wfs with different input, but the second node has the same input;
@@ -2348,7 +2255,6 @@ def test_wf_nostate_nodecachelocations(plugin, tmpdir):
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_nodecachelocations_upd(plugin, tmpdir):
     """
     Two wfs with different input, but the second node has the same input;
@@ -2398,7 +2304,6 @@ def test_wf_nostate_nodecachelocations_upd(plugin, tmpdir):
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_state_cachelocations(plugin, tmpdir):
     """
     Two identical wfs (with states) with provided cache_dir;
@@ -2463,7 +2368,6 @@ def test_wf_state_cachelocations(plugin, tmpdir):
         assert not odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_state_cachelocations_forcererun(plugin, tmpdir):
     """
     Two identical wfs (with states) with provided cache_dir;
@@ -2529,7 +2433,6 @@ def test_wf_state_cachelocations_forcererun(plugin, tmpdir):
         assert odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_state_cachelocations_updateinp(plugin, tmpdir):
     """
     Two identical wfs (with states) with provided cache_dir;
@@ -2597,7 +2500,6 @@ def test_wf_state_cachelocations_updateinp(plugin, tmpdir):
         assert not odir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_state_n_nostate_cachelocations(plugin, tmpdir):
     """
     Two wfs with provided cache_dir, the first one has no state, the second has;
@@ -2648,7 +2550,6 @@ def test_wf_state_n_nostate_cachelocations(plugin, tmpdir):
     assert wf2.output_dir[1].exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachelocations_updated(plugin, tmpdir):
     """
     Two identical wfs with provided cache_dir;
@@ -2707,7 +2608,6 @@ def test_wf_nostate_cachelocations_updated(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
     """
     Two wfs with the same inputs but slightly different graph;
@@ -2764,7 +2664,6 @@ def test_wf_nostate_cachelocations_recompute(plugin, tmpdir):
     assert len(list(Path(cache_dir2).glob("F*"))) == 1
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstate_cachelocations(plugin, tmpdir):
     """
     Two wfs with identical inputs and node states;
@@ -2826,7 +2725,6 @@ def test_wf_ndstate_cachelocations(plugin, tmpdir):
     assert not wf2.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstate_cachelocations_forcererun(plugin, tmpdir):
     """
     Two wfs with identical inputs and node states;
@@ -2888,7 +2786,6 @@ def test_wf_ndstate_cachelocations_forcererun(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstate_cachelocations_updatespl(plugin, tmpdir):
     """
     Two wfs with identical inputs and node state (that is set after adding the node!);
@@ -2950,7 +2847,6 @@ def test_wf_ndstate_cachelocations_updatespl(plugin, tmpdir):
     assert not wf2.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_ndstate_cachelocations_recompute(plugin, tmpdir):
     """
     Two wfs (with nodes with states) with provided cache_dir;
@@ -3012,7 +2908,6 @@ def test_wf_ndstate_cachelocations_recompute(plugin, tmpdir):
     assert wf2.output_dir.exists()
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_nostate_runtwice_usecache(plugin, tmpdir):
     """
     running worflow (without state) twice,
@@ -3049,7 +2944,6 @@ def test_wf_nostate_runtwice_usecache(plugin, tmpdir):
     assert cache_dir_content == os.listdir(wf1.cache_dir)
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_state_runtwice_usecache(plugin, tmpdir):
     """
     running worflow with a state twice,
@@ -3168,7 +3062,6 @@ def test_workflow_combine2(tmpdir):
 # testing lzout.all to collect all of the results and let FunctionTask deal with it
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_lzoutall_1(plugin):
     """ workflow with 2 tasks, no splitter
         passing entire result object to add2_sub2_res function
@@ -3190,7 +3083,6 @@ def test_wf_lzoutall_1(plugin):
     assert 8 == results.output.out
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_lzoutall_1a(plugin):
     """ workflow with 2 tasks, no splitter
         passing entire result object to add2_res function
@@ -3212,7 +3104,6 @@ def test_wf_lzoutall_1a(plugin):
     assert results.output.out_all == {"out_add": 8, "out_sub": 4}
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_lzoutall_st_1(plugin):
     """ workflow with 2 tasks, no splitter
         passing entire result object to add2_res function
@@ -3234,7 +3125,6 @@ def test_wf_lzoutall_st_1(plugin):
     assert results.output.out_add == [8, 62, 62, 602]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_lzoutall_st_1a(plugin):
     """ workflow with 2 tasks, no splitter
         passing entire result object to add2_res function
@@ -3261,7 +3151,6 @@ def test_wf_lzoutall_st_1a(plugin):
     ]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_lzoutall_st_2(plugin):
     """ workflow with 2 tasks, no splitter
         passing entire result object to add2_res function
@@ -3286,7 +3175,6 @@ def test_wf_lzoutall_st_2(plugin):
     assert results.output.out_add[1] == [62, 602]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_lzoutall_st_2a(plugin):
     """ workflow with 2 tasks, no splitter
         passing entire result object to add2_res function
@@ -3316,7 +3204,6 @@ def test_wf_lzoutall_st_2a(plugin):
 # worfklows that have files in the result, the files should be copied to the wf dir
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_resultfile_1(plugin):
     """ workflow with a file in the result, file should be copied to the wf dir"""
     wf = Workflow(name="wf_file_1", input_spec=["x"])
@@ -3334,7 +3221,6 @@ def test_wf_resultfile_1(plugin):
     assert results.output.wf_out == wf.output_dir / "file_1.txt"
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_resultfile_2(plugin):
     """ workflow with a list of files in the wf result,
         all files should be copied to the wf dir
@@ -3356,7 +3242,6 @@ def test_wf_resultfile_2(plugin):
         assert file == wf.output_dir / file_list[ii]
 
 
-@pytest.mark.parametrize("plugin", Plugins)
 def test_wf_resultfile_3(plugin):
     """ workflow with a dictionaries of files in the wf result,
         all files should be copied to the wf dir

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -24,16 +24,15 @@ from ..submitter import Submitter
 from ..core import Workflow
 
 
-def test_wf_1(plugin_dask_opt):
+def test_wf_1(plugin):
     """ workflow with one task and no splitter"""
     wf = Workflow(name="wf_1", input_spec=["x"])
     wf.add(add2(name="add2", x=wf.lzin.x))
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
-    wf.plugin = plugin_dask_opt
 
     checksum_before = wf.checksum
-    with Submitter(plugin=plugin_dask_opt) as sub:
+    with Submitter(plugin=plugin) as sub:
         sub(wf)
 
     assert wf.checksum == checksum_before
@@ -218,6 +217,7 @@ def test_wf_2d_outpasdict(plugin):
     assert wf.output_dir.exists()
 
 
+@pytest.mark.flaky(reruns=2)  # when dask
 def test_wf_3(plugin_dask_opt):
     """ testing None value for an input"""
     wf = Workflow(name="wf_3", input_spec=["x", "y"])
@@ -226,7 +226,6 @@ def test_wf_3(plugin_dask_opt):
     wf.set_output([("out", wf.add2.lzout.out)])
     wf.inputs.x = 2
     wf.inputs.y = None
-    wf.plugin = plugin_dask_opt
 
     with Submitter(plugin=plugin_dask_opt) as sub:
         sub(wf)
@@ -837,6 +836,7 @@ def test_wf_3sernd_ndst_1(plugin):
 # workflows with structures A -> C, B -> C
 
 
+@pytest.mark.flaky(reruns=2)  # when dask
 def test_wf_3nd_st_1(plugin_dask_opt):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter on the workflow level
@@ -863,6 +863,7 @@ def test_wf_3nd_st_1(plugin_dask_opt):
         assert odir.exists()
 
 
+@pytest.mark.flaky(reruns=2)  # when dask
 def test_wf_3nd_ndst_1(plugin_dask_opt):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter on the tasks levels
@@ -972,7 +973,7 @@ def test_wf_3nd_st_3(plugin):
         assert odir.exists()
 
 
-def test_wf_3nd_ndst_3(plugin_dask_opt):
+def test_wf_3nd_ndst_3(plugin):
     """ workflow with three tasks, third one connected to two previous tasks,
         splitter and partial combiner (from the second task) on the tasks levels
     """
@@ -988,7 +989,7 @@ def test_wf_3nd_ndst_3(plugin_dask_opt):
     wf.inputs.y = [11, 12]
     wf.set_output([("out", wf.mult.lzout.out)])
 
-    with Submitter(plugin=plugin_dask_opt) as sub:
+    with Submitter(plugin=plugin) as sub:
         sub(wf)
 
     results = wf.result()

--- a/pydra/engine/tests/utils.py
+++ b/pydra/engine/tests/utils.py
@@ -1,11 +1,39 @@
 # Tasks for testing
 import time
+import sys, shutil
 import typing as tp
 from pathlib import Path
+import subprocess as sp
+import pytest
 
 from ..core import Workflow
+from ..submitter import Submitter
 from ... import mark
 from ..specs import File
+
+
+need_docker = pytest.mark.skipif(
+    shutil.which("docker") is None or sp.call(["docker", "info"]),
+    reason="no docker within the container",
+)
+no_win = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="docker command not adjusted for windows docker",
+)
+
+
+def result_no_submitter(shell_task, plugin=None):
+    """ helper function to return result when running without submitter """
+    return shell_task()
+
+
+def result_submitter(shell_task, plugin):
+    """ helper function to return result when running with submitter
+        with specific plugin
+    """
+    with Submitter(plugin=plugin) as sub:
+        shell_task(submitter=sub)
+    return shell_task.result()
 
 
 @mark.task

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ test_requires =
     pytest-cov
     pytest-env
     pytest-xdist
+    pytest-rerunfailures
     codecov
     numpy
     psutil
@@ -41,6 +42,7 @@ test_requires =
     notebook==5.7.8
     jupyter
     jupyter_contrib_nbextensions
+    boutiques
 packages = find:
 include_package_data = True
 
@@ -65,6 +67,7 @@ test =
     pytest-cov
     pytest-env
     pytest-xdist
+    pytest-rerunfailures
     codecov
     numpy
     pyld
@@ -74,6 +77,7 @@ test =
     notebook==5.7.8
     jupyter
     jupyter_contrib_nbextensions
+    boutiques
 tests =
     %(test)s
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,14 +33,12 @@ test_requires =
     pytest-cov
     pytest-env
     pytest-xdist
-    dask
-    distributed
     codecov
     numpy
     psutil
-    tornado
+    tornado==4.5.3
     nbformat
-    notebook
+    notebook==5.7.8
     jupyter
     jupyter_contrib_nbextensions
 packages = find:
@@ -67,6 +65,25 @@ test =
     pytest-cov
     pytest-env
     pytest-xdist
+    codecov
+    numpy
+    pyld
+    psutil
+    tornado==4.5.3
+    nbformat
+    notebook==5.7.8
+    jupyter
+    jupyter_contrib_nbextensions
+tests =
+    %(test)s
+dev =
+    %(test)s
+    black
+    pre-commit
+dask =
+    pytest-cov
+    pytest-env
+    pytest-xdist
     dask
     distributed
     codecov
@@ -78,12 +95,6 @@ test =
     notebook
     jupyter
     jupyter_contrib_nbextensions
-tests =
-    %(test)s
-dev =
-    %(test)s
-    black
-    pre-commit
 all =
     %(doc)s
     %(dev)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -85,12 +85,11 @@ dev =
     black
     pre-commit
 dask =
+    pytest >= 4.4.0
     pytest-cov
     pytest-env
     pytest-xdist
     pytest-rerunfailures
-    dask
-    distributed
     codecov
     numpy
     pyld
@@ -100,6 +99,8 @@ dask =
     notebook
     jupyter
     jupyter_contrib_nbextensions
+    dask
+    distributed
 all =
     %(doc)s
     %(dev)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,7 @@ dask =
     pytest-cov
     pytest-env
     pytest-xdist
+    pytest-rerunfailures
     dask
     distributed
     codecov


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Summary
<!--- What does your code do? -->
I really have issue with running more than few testing with dask on my laptop, not really sure why...
At the end I've decided to have a separate travis run with `test_dask` option that runs only subset of tests that have `plugin_dask_opt` (passing `--dask` argument to pytest).
Configured plugin seetings in `conftest.py`



## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [ ] I acknowledge that this contribution will be available under the Apache 2 license.